### PR TITLE
Prøvde å style opp happenings overview litt

### DIFF
--- a/frontend/src/components/section.tsx
+++ b/frontend/src/components/section.tsx
@@ -5,15 +5,7 @@ import React from 'react';
 const Section = (props: BoxProps): JSX.Element => {
     const bg = useColorModeValue('bg.light.secondary', 'bg.dark.secondary');
     return (
-        <Box
-            bg={bg}
-            p="6"
-            overflow="hidden"
-            shadow="lg"
-            borderRadius="0.5rem"
-            boxShadow="0 10px 20px 0 rgba(0, 0, 0, 0.1)"
-            {...props}
-        />
+        <Box bg={bg} p="6" shadow="lg" borderRadius="0.5rem" boxShadow="0 10px 20px 0 rgba(0, 0, 0, 0.1)" {...props} />
     );
 };
 

--- a/frontend/src/pages/happenings-overview/index.tsx
+++ b/frontend/src/pages/happenings-overview/index.tsx
@@ -1,5 +1,4 @@
 import {
-    Box,
     Divider,
     Flex,
     Heading,

--- a/frontend/src/pages/happenings-overview/index.tsx
+++ b/frontend/src/pages/happenings-overview/index.tsx
@@ -1,7 +1,11 @@
 import {
+    Box,
     Divider,
     Flex,
     Heading,
+    HStack,
+    Icon,
+    IconProps,
     LinkBox,
     Popover,
     PopoverArrow,
@@ -14,7 +18,6 @@ import {
     Stack,
     Text,
     useColorModeValue,
-    // useColorModeValue,
 } from '@chakra-ui/react';
 import { addWeeks, getISOWeek, lastDayOfWeek, startOfWeek, subWeeks } from 'date-fns';
 import Markdown from 'markdown-to-jsx';
@@ -136,12 +139,20 @@ const getWeekDatesFromDate = (date: Date): Array<Date> => {
     return getDatesInRange(firstWeekDay, lastWeekDay);
 };
 
+const CircleIcon = (props: IconProps) => (
+    <Icon viewBox="0 0 200 200" {...props}>
+        <path fill="currentColor" d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0" />
+    </Icon>
+);
+
 interface Props {
     events: Array<Happening>;
 }
 const HappeningsOverviewPage = ({ events }: Props): JSX.Element => {
     const [date, setDate] = useState(new Date());
     const currentWeek = getWeekDatesFromDate(date);
+    const bedpresColor = useColorModeValue('highlight.light.primary', 'highlight.dark.primary');
+    const otherColor = useColorModeValue('highlight.light.secondary', 'highlight.dark.secondary');
 
     return (
         <>
@@ -160,6 +171,16 @@ const HappeningsOverviewPage = ({ events }: Props): JSX.Element => {
                     </Button>
                 </Flex>
             </Flex>
+            <HStack alignItems="center" gap={5}>
+                <Flex alignItems="inherit">
+                    <CircleIcon color={bedpresColor} />
+                    Bedpres
+                </Flex>
+                <Flex alignItems="inherit">
+                    <CircleIcon color={otherColor} />
+                    Annet
+                </Flex>
+            </HStack>
             <SimpleGrid as={Section} padding="1rem" columns={[1, 2, 3, 7]} gridGap="1rem">
                 {currentWeek.map((x) => (
                     <HappeningsColumn key={x.toString()} date={x} events={events} />

--- a/frontend/src/pages/happenings-overview/index.tsx
+++ b/frontend/src/pages/happenings-overview/index.tsx
@@ -51,20 +51,21 @@ const datesAreOnSameDay = (first: Date, second: Date) =>
 const HappeningBox = ({ type, title, slug, location, body, author }: HappeningBoxProps) => {
     const bedpresColor = useColorModeValue('highlight.light.primary', 'highlight.dark.primary');
     const otherColor = useColorModeValue('highlight.light.secondary', 'highlight.dark.secondary');
+
     return (
         <LinkBox
             bg={type === HappeningType.BEDPRES ? bedpresColor : otherColor}
-            p="1"
+            p="2"
             borderRadius="0.25rem"
             _hover={{ cursor: 'pointer' }}
         >
-            <NextLink href={`/event/${slug}`}>
-                <Popover trigger="hover">
-                    <PopoverTrigger>
-                        <Text noOfLines={1} color="black">
-                            {title}
-                        </Text>
-                    </PopoverTrigger>
+            <Popover>
+                <PopoverTrigger>
+                    <Text noOfLines={1} fontSize="lg" color="black">
+                        {title}
+                    </Text>
+                </PopoverTrigger>
+                <NextLink href={`/event/${slug}`} passHref>
                     <PopoverContent>
                         <PopoverArrow />
                         <PopoverHeader>
@@ -77,7 +78,7 @@ const HappeningBox = ({ type, title, slug, location, body, author }: HappeningBo
                             )}
                             <Text fontWeight="extrabold">{title}</Text>
                         </PopoverHeader>
-                        <PopoverBody>
+                        <PopoverBody fontSize="lg">
                             <Text>@ {location}</Text>
                             <Divider />
                             <Text noOfLines={5}>
@@ -88,8 +89,8 @@ const HappeningBox = ({ type, title, slug, location, body, author }: HappeningBo
                             </Text>
                         </PopoverBody>
                     </PopoverContent>
-                </Popover>
-            </NextLink>
+                </NextLink>
+            </Popover>
         </LinkBox>
     );
 };
@@ -163,10 +164,10 @@ const HappeningsOverviewPage = ({ events }: Props): JSX.Element => {
                 <Spacer />
                 <Flex justifyContent="center">
                     <Button leftIcon={<BiLeftArrow />} onClick={() => setDate(subWeeks(date, 1))} marginRight="1rem">
-                        forrige uke
+                        Forrige uke
                     </Button>
                     <Button rightIcon={<BiRightArrow />} onClick={() => setDate(addWeeks(date, 1))}>
-                        neste uke
+                        Neste uke
                     </Button>
                 </Flex>
             </Flex>

--- a/frontend/src/pages/happenings-overview/index.tsx
+++ b/frontend/src/pages/happenings-overview/index.tsx
@@ -1,17 +1,23 @@
 import {
-    Box,
     Divider,
     Flex,
     Heading,
     LinkBox,
-    LinkOverlay,
+    Popover,
+    PopoverArrow,
+    PopoverBody,
+    PopoverContent,
+    PopoverHeader,
+    PopoverTrigger,
     SimpleGrid,
     Spacer,
     Stack,
     Text,
     useColorModeValue,
+    // useColorModeValue,
 } from '@chakra-ui/react';
 import { addWeeks, getISOWeek, lastDayOfWeek, startOfWeek, subWeeks } from 'date-fns';
+import Markdown from 'markdown-to-jsx';
 import { GetStaticProps } from 'next';
 import NextLink from 'next/link';
 import React, { useState } from 'react';
@@ -26,15 +32,69 @@ interface EventsStackProps {
     date: Date;
 }
 
+interface HappeningBoxProps {
+    type: HappeningType;
+    title: string;
+    slug: string;
+    location: string;
+    author: string;
+    body: string;
+}
+
 const datesAreOnSameDay = (first: Date, second: Date) =>
     first.getFullYear() === second.getFullYear() &&
     first.getMonth() === second.getMonth() &&
     first.getDate() === second.getDate();
 
+const HappeningBox = ({ type, title, slug, location, body, author }: HappeningBoxProps) => {
+    const bedpresColor = useColorModeValue('highlight.light.primary', 'highlight.dark.primary');
+    const otherColor = useColorModeValue('highlight.light.secondary', 'highlight.dark.secondary');
+    return (
+        <LinkBox
+            bg={type === HappeningType.BEDPRES ? bedpresColor : otherColor}
+            p="1"
+            borderRadius="0.25rem"
+            _hover={{ cursor: 'pointer' }}
+        >
+            <NextLink href={`/event/${slug}`}>
+                <Popover trigger="hover">
+                    <PopoverTrigger>
+                        <Text noOfLines={1} color="black">
+                            {title}
+                        </Text>
+                    </PopoverTrigger>
+                    <PopoverContent>
+                        <PopoverArrow />
+                        <PopoverHeader>
+                            {type === HappeningType.BEDPRES ? (
+                                <Text as="em" fontWeight="bold" fontSize="sm">
+                                    Bedpres
+                                </Text>
+                            ) : (
+                                ''
+                            )}
+                            <Text fontWeight="extrabold">{title}</Text>
+                        </PopoverHeader>
+                        <PopoverBody>
+                            <Text>@ {location}</Text>
+                            <Divider />
+                            <Text noOfLines={5}>
+                                <Markdown>{body}</Markdown>
+                            </Text>
+                            <Text as="em" fontSize="sm">
+                                {author}
+                            </Text>
+                        </PopoverBody>
+                    </PopoverContent>
+                </Popover>
+            </NextLink>
+        </LinkBox>
+    );
+};
+
 const HappeningsColumn = ({ events, date }: EventsStackProps): React.ReactElement => {
     const eventsThisDay = events.filter((x) => datesAreOnSameDay(new Date(x.date), date));
     const formattedDate = date.toLocaleDateString('nb-NO', { weekday: 'long', month: 'short', day: 'numeric' });
-    const titleColor = useColorModeValue('highlight.light.primary', 'highlight.dark.primary');
 
     return (
         <Stack>
@@ -42,22 +102,17 @@ const HappeningsColumn = ({ events, date }: EventsStackProps): React.ReactElemen
                 {formattedDate}
             </Text>
             <Divider />
-            {eventsThisDay.map((event) => {
-                return (
-                    <LinkBox key={event.slug}>
-                        <NextLink href={`/event/${event.slug}`} passHref>
-                            <LinkOverlay _hover={{ textDecorationLine: 'underline' }}>
-                                <Box>
-                                    <Text marginBottom="1rem" fontSize="0.8em" color={titleColor}>
-                                        {event.happeningType === HappeningType.BEDPRES ? 'Bedpres: ' : ''}
-                                        {event.title}
-                                    </Text>
-                                </Box>
-                            </LinkOverlay>
-                        </NextLink>
-                    </LinkBox>
-                );
-            })}
+            {eventsThisDay.map((event) => (
+                <HappeningBox
+                    key={event.slug}
+                    type={event.happeningType}
+                    title={event.title}
+                    slug={event.slug}
+                    location={event.location}
+                    body={event.body}
+                    author={event.author}
+                />
+            ))}
         </Stack>
     );
 };
@@ -106,9 +161,9 @@ const HappeningsOverviewPage = ({ events }: Props): JSX.Element => {
                 </Flex>
             </Flex>
             <SimpleGrid as={Section} padding="1rem" columns={[1, 2, 3, 7]} gridGap="1rem">
-                {currentWeek.map((x) => {
-                    return <HappeningsColumn key={x.toString()} date={x} events={events} />;
-                })}
+                {currentWeek.map((x) => (
+                    <HappeningsColumn key={x.toString()} date={x} events={events} />
+                ))}
             </SimpleGrid>
         </>
     );

--- a/frontend/src/pages/job/index.tsx
+++ b/frontend/src/pages/job/index.tsx
@@ -11,7 +11,7 @@ interface Props {
 const JobPage = ({ jobAdverts }: Props) => {
     return (
         <Section>
-            <JobAdvertOverview jobAdverts={jobAdverts} />;
+            <JobAdvertOverview jobAdverts={jobAdverts} />
         </Section>
     );
 };


### PR DESCRIPTION
Tittelen i selve kalenderen kan nå bare ha en linje, men du kan nå hovere over den for å få litt mer informasjon om event/bedpres. De er også fargekoordinert. Hvis du trykker på greia så blir du sendt videre til selve siden.

**OBS!**
Denne commiten fjerner `overflow: hidden` fra `section.tsx`. Tror ikke det skal ødelegge noe, men kanskje være litt obs på dette om noe blir rart i fremtiden.

![Screenshot 2022-05-10 at 16 42 36](https://user-images.githubusercontent.com/32321558/167657043-822ae41c-9766-4059-aee3-33ede493e5fe.png)
![Screenshot 2022-05-10 at 16 42 32](https://user-images.githubusercontent.com/32321558/167657051-172bb0ae-3956-441d-bd99-797e910f6ec6.png)
 