### PR TITLE
✅ Add tests for database migration

### DIFF
--- a/.github/workflows/docker_tests.yaml
+++ b/.github/workflows/docker_tests.yaml
@@ -106,3 +106,35 @@ jobs:
           SANITY_DATASET: testing
           ADMIN_KEY: admin-passord
           NEXTAUTH_SECRET: very-secret-string-123
+
+  migration_tests:
+    runs-on: ubuntu-latest
+    needs: [build_backend]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Pull Docker image
+        run: docker pull "$IMAGE_NAME/backend:$GITHUB_SHA"
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+
+      - name: Download database dump
+        run: |
+          heroku pg:backups:capture -a $HEROKU_APP_NAME
+          heroku pg:backups:download -a $HEROKU_APP_NAME
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEROKU_APP_NAME: 'echo-web-backend-prod'
+
+      - name: Run migration tests
+        run: |
+          docker compose -f backend/docker-compose.yaml up database --wait
+          docker cp latest.dump backend-database-1:/
+          docker exec -i backend-database-1 pg_restore --verbose --clean --no-acl --no-owner -h localhost -U postgres -d postgres latest.dump || true
+          docker compose -f backend/docker-compose.yaml up backend & (sleep 15 && docker kill backend-backend-1)
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          TAG: ${{ github.sha }}
+          TEST_MIGRATION: true
+          ADMIN_KEY: admin-passord

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,6 +3,7 @@ kt/
 !.env.example
 .graphqlconfig
 schema.graphql
+*.dump
 
 ### Created by https://www.gitignore.io
 ### Intellij+all ###

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -4,8 +4,8 @@ services:
     build:
       context: .
       cache_from:
-        - '${REGISTRY:-ghcr.io}/echo-webkom/backend:${TAG:-latest}'
-    image: '${REGISTRY:-ghcr.io}/echo-webkom/backend:${TAG:-latest}'
+        - '${IMAGE_NAME:-echo-webkom/echo-web}/backend:${TAG:-latest}'
+    image: '${IMAGE_NAME:-echo-webkom/echo-web}/backend:${TAG:-latest}'
     # Don't start backend before database is up.
     depends_on:
       database:
@@ -23,6 +23,7 @@ services:
       SENDGRID_API_KEY:
       SEND_EMAIL_REGISTRATION:
       SEND_EMAIL_HAPPENING:
+      TEST_MIGRATION:
 
   database:
     # Postgres 13.6 is the version Heroku uses.

--- a/backend/src/main/kotlin/no/uib/echo/Application.kt
+++ b/backend/src/main/kotlin/no/uib/echo/Application.kt
@@ -35,6 +35,7 @@ fun Application.module() {
     }
 
     val dev = environment.config.propertyOrNull("ktor.dev") != null
+    val testMigration = environment.config.property("ktor.testMigration").getString().toBooleanStrict()
     val adminKey = environment.config.property("ktor.adminKey").getString()
     val databaseUrl = URI(environment.config.property("ktor.databaseUrl").getString())
     val mbMaxPoolSize = environment.config.propertyOrNull("ktor.maxPoolSize")?.getString()
@@ -50,7 +51,7 @@ fun Application.module() {
     if (sendGridApiKey == null && !dev && (sendEmailReg || sendEmailHap))
         throw Exception("SENDGRID_API_KEY not defined in non-dev environment, with SEND_EMAIL_REGISTRATION = $sendEmailReg and SEND_EMAIL_HAPPENING = $sendEmailHap.")
 
-    DatabaseHandler(dev, databaseUrl, mbMaxPoolSize).init()
+    DatabaseHandler(dev, testMigration, databaseUrl, mbMaxPoolSize).init()
 
     configureRouting(
         adminKey,

--- a/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
+++ b/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
@@ -16,7 +16,7 @@ import java.net.URI
 private const val DEFAULT_DEV_POOL_SIZE = 10
 private const val DEFAULT_PROD_POOL_SIZE = 50
 
-class DatabaseHandler(private val dev: Boolean, dbUrl: URI, mbMaxPoolSize: String?) {
+class DatabaseHandler(private val dev: Boolean, private val testMigration: Boolean, dbUrl: URI, mbMaxPoolSize: String?) {
     private val dbPort = if (dbUrl.port == -1) 5432 else dbUrl.port
     private val dbUrl = "jdbc:postgresql://${dbUrl.host}:${dbPort}${dbUrl.path}"
     private val dbUsername = dbUrl.userInfo.split(":")[0]
@@ -49,7 +49,7 @@ class DatabaseHandler(private val dev: Boolean, dbUrl: URI, mbMaxPoolSize: Strin
 
     fun init() {
         // Don't migrate if running on local machine
-        if (!dev) {
+        if (!dev || testMigration) {
             migrate()
             // Need to use connection once to open.
             transaction(conn) {}

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -8,6 +8,7 @@ ktor {
     }
 
     # Default values
+    testMigration = false
     sendEmailRegistration = false
     sendEmailHappening = true
     verifyRegs = true
@@ -18,6 +19,7 @@ ktor {
 
     # Optional variables (note question mark notation)
     dev = ${?DEV}
+    testMigration = ${?TEST_MIGRATION}
     sendEmailRegistration = ${?SEND_EMAIL_REGISTRATION}
     sendEmailHappening = ${?SEND_EMAIL_HAPPENING}
     verifyRegs = ${?VERIFY_REGS}

--- a/backend/src/main/resources/db/migration/V16__Failing_migration.sql
+++ b/backend/src/main/resources/db/migration/V16__Failing_migration.sql
@@ -1,2 +1,0 @@
-ALTER TABLE bruh_moment
-ADD COLUMN fail_69 TEXT;

--- a/backend/src/main/resources/db/migration/V16__Failing_migration.sql
+++ b/backend/src/main/resources/db/migration/V16__Failing_migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bruh_moment
+ADD COLUMN fail_69 TEXT;

--- a/backend/src/test/kotlin/no/uib/echo/HappeningRegistrationTest.kt
+++ b/backend/src/test/kotlin/no/uib/echo/HappeningRegistrationTest.kt
@@ -196,7 +196,7 @@ class HappeningRegistrationTest : StringSpec({
     val featureToggles =
         FeatureToggles(sendEmailReg = false, sendEmailHap = false, rateLimit = false, verifyRegs = false)
 
-    beforeSpec { DatabaseHandler(true, URI(System.getenv("DATABASE_URL")), null).init() }
+    beforeSpec { DatabaseHandler(dev = true, testMigration = false, URI(System.getenv("DATABASE_URL")), null).init() }
     beforeTest {
         transaction {
             SchemaUtils.drop(

--- a/backend/src/test/kotlin/no/uib/echo/HappeningTest.kt
+++ b/backend/src/test/kotlin/no/uib/echo/HappeningTest.kt
@@ -48,7 +48,7 @@ class HappeningTest : StringSpec({
     val auth = "admin:$adminKey"
     val featureToggles = FeatureToggles(sendEmailReg = false, sendEmailHap = false, rateLimit = false, verifyRegs = false)
 
-    beforeSpec { DatabaseHandler(true, URI(System.getenv("DATABASE_URL")), null).init() }
+    beforeSpec { DatabaseHandler(dev = true, testMigration = false, URI(System.getenv("DATABASE_URL")), null).init() }
     beforeTest {
         transaction {
             SchemaUtils.drop(


### PR DESCRIPTION
Legger til tester for database migrations, altså alle SQL-filer i `backend/src/main/resources/db/migration/`.

Om legger til en ny SQL-fil der så blir koden i den kjørt mot en fersk backup av (prod) databasen fra Heroku.

Skal gjøre det umulig å pushe ugyldig SQL-kode.