### PR TITLE
📱 Fix post preview title overflow on mobile

### DIFF
--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -15,7 +15,7 @@ const Layout = ({ children }: Props): JSX.Element => {
                 <Header />
                 <Box
                     maxW="1500"
-                    w="90%"
+                    w={['97%', null, null, '90%']}
                     m="auto"
                     px={['0', '5%', '50']}
                     pb={['610px', '370px', '250px', '200px', '200px']}

--- a/frontend/src/components/post-preview.tsx
+++ b/frontend/src/components/post-preview.tsx
@@ -1,8 +1,9 @@
-import { BoxProps, Heading, LinkBox, LinkOverlay, Text, useColorModeValue } from '@chakra-ui/react';
+import { BoxProps, Heading, LinkBox, LinkOverlay, Text, useBreakpointValue, useColorModeValue } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import React from 'react';
 import removeMD from 'remove-markdown';
 import { Post } from '../lib/api';
+import { hasLongWord } from '../lib/utils';
 
 interface Props extends BoxProps {
     post: Post;
@@ -13,6 +14,7 @@ const PostPreview = ({ post, ...props }: Props): JSX.Element => {
     const borderColor = useColorModeValue('bg.light.border', 'bg.dark.border');
     const bgColor = useColorModeValue('bg.light.tertiary', 'bg.dark.tertiary');
     const textColor = useColorModeValue('text.light.secondary', 'text.dark.secondary');
+    const isMobile = useBreakpointValue([true, false]);
 
     return (
         <LinkBox
@@ -35,7 +37,7 @@ const PostPreview = ({ post, ...props }: Props): JSX.Element => {
             <NextLink href={`/posts/${post.slug}`} passHref>
                 <LinkOverlay>
                     <Heading pt="1rem" size="lg" mb="1em" noOfLines={[2, null, null, 3]}>
-                        {post.title}
+                        {isMobile && hasLongWord(post.title) ? [...post.title.slice(0, 27), '...'] : post.title}
                     </Heading>
                     <Text fontStyle="italic">{`«${removeMD(post.body.slice(0, 100))} ...»`}</Text>
                 </LinkOverlay>

--- a/frontend/src/components/registration-row.tsx
+++ b/frontend/src/components/registration-row.tsx
@@ -20,7 +20,7 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import { motion } from 'framer-motion';
 import { Registration, RegistrationAPI } from '../lib/api';
-import notEmptyOrNull from '../lib/utils';
+import { notEmptyOrNull } from '../lib/utils';
 
 interface Props {
     registration: Registration;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,3 +1,9 @@
 const notEmptyOrNull = <E>(e: Array<E> | null) => e && e.length > 0;
 
-export default notEmptyOrNull;
+const hasLongWord = (text: string): boolean =>
+    text
+        .split(' ')
+        .map((word: string) => word.length > 18)
+        .some(Boolean);
+
+export { hasLongWord, notEmptyOrNull };

--- a/frontend/src/pages/registration/[slug].tsx
+++ b/frontend/src/pages/registration/[slug].tsx
@@ -21,7 +21,7 @@ import ButtonLink from '../../components/button-link';
 import { isErrorMessage, RegistrationAPI, Registration, registrationRoute } from '../../lib/api';
 import Section from '../../components/section';
 import RegistrationRow from '../../components/registration-row';
-import notEmptyOrNull from '../../lib/utils';
+import { notEmptyOrNull } from '../../lib/utils';
 
 interface Props {
     registrations: Array<Registration> | null;


### PR DESCRIPTION
Problemet var at lange sammenhengende ord fikk `PostPreview` til å gå over bredden til `Section`.
Prøve å fikse det med `noOfLines` og `maxWidth`, men det virket ikke.
Lagde en workaround for lange ord, som ikke burde endre på poster uten lange ord.

Økte også bredden på alle seksjonene på forsiden på mobil.

# Før
![2022-05-29_16:01:28](https://user-images.githubusercontent.com/6720179/170872990-941311ff-e231-4d73-9b1f-3e4fa9ac26c7.png)

# Etter
![2022-05-29_16:01:06](https://user-images.githubusercontent.com/6720179/170872993-c88255a3-4061-4338-8aa8-15f15d1fd889.png)