### PR TITLE
fixing the cutoff of the badge for the posts at the bottom in /posts

### DIFF
--- a/frontend/src/components/post-list.tsx
+++ b/frontend/src/components/post-list.tsx
@@ -10,7 +10,7 @@ interface Props {
 const PostList = ({ posts }: Props): JSX.Element => {
     return (
         <Center>
-            <Wrap pt="1rem" className="post-list" spacing={8} w="100%" justify="center">
+            <Wrap pt="1rem" className="post-list" spacing={8} paddingBottom="20px" w="100%" justify="center">
                 {posts.map((post: Post) => {
                     return <PostPreview key={post.slug} post={post} data-testid={post.slug} w="22em" />;
                 })}


### PR DESCRIPTION
fix for [denne](https://trello.com/c/gehmET6A/147-badge-p%C3%A5-innleggs-preview-flyter-ikke-over)

dette er ikke den beste løsningen men det fungerer. 
hvis jeg setter margin = 0 på ul-en i inspect (chrome) så blir det fikset, men jeg får det ikke til i koden.
![image](https://user-images.githubusercontent.com/68005825/176572065-7a1071e1-9218-44a7-b15a-891708cd1dbc.png)
