### PR TITLE
💚 Include 'fetch-depth' for Docker build on push

### DIFF
--- a/.github/workflows/docker_push.yaml
+++ b/.github/workflows/docker_push.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
@@ -65,6 +67,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Get changed files
         id: changed-files


### PR DESCRIPTION
Er sånn det skal gjøres for push events: https://github.com/tj-actions/changed-files#Usage.

Gjør at PR der hvor bare frontend eller backend har endret seg får riktig versjon av Docker image.
F.eks. burde https://github.com/echo-webkom/echo-web/pull/250 ikke faile med denne fixen.