### PR TITLE
🐛 Dynamic theme color

### DIFF
--- a/frontend/src/components/color-mode-button.tsx
+++ b/frontend/src/components/color-mode-button.tsx
@@ -2,6 +2,7 @@ import { Box, HStack, Switch, useColorMode, useColorModeValue } from '@chakra-ui
 import React, { ChangeEvent } from 'react';
 import { BsSun } from 'react-icons/bs';
 import { BiMoon } from 'react-icons/bi';
+import Head from 'next/head';
 
 const ColorModeButton = (): JSX.Element => {
     const { colorMode, toggleColorMode } = useColorMode();
@@ -10,23 +11,28 @@ const ColorModeButton = (): JSX.Element => {
     const label = 'colormode-button';
 
     return (
-        <HStack data-cy={label}>
-            <Box color={sunBg}>
-                <BsSun />
-            </Box>
-            <Switch
-                aria-label={label}
-                size="lg"
-                isChecked={colorMode === 'light' ? false : true}
-                onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                    if (event.target.checked && colorMode === 'light') toggleColorMode();
-                    else if (!event.target.checked && colorMode === 'dark') toggleColorMode();
-                }}
-            />
-            <Box color={moonBg}>
-                <BiMoon />
-            </Box>
-        </HStack>
+        <>
+            <Head>
+                <meta name="theme-color" content={colorMode === 'light' ? '#5bbad5' : '#1e1e1e'} />
+            </Head>
+            <HStack data-cy={label}>
+                <Box color={sunBg}>
+                    <BsSun />
+                </Box>
+                <Switch
+                    aria-label={label}
+                    size="lg"
+                    isChecked={colorMode === 'light' ? false : true}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                        if (event.target.checked && colorMode === 'light') toggleColorMode();
+                        else if (!event.target.checked && colorMode === 'dark') toggleColorMode();
+                    }}
+                />
+                <Box color={moonBg}>
+                    <BiMoon />
+                </Box>
+            </HStack>
+        </>
     );
 };
 

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -1,4 +1,4 @@
-import { ColorModeScript, useColorModeValue } from '@chakra-ui/react';
+import { ColorModeScript } from '@chakra-ui/react';
 import Document, { DocumentContext, DocumentInitialProps, Head, Html, Main, NextScript } from 'next/document';
 import React from 'react';
 import theme from '../styles/theme';
@@ -9,17 +9,14 @@ const getInitialProps = async (ctx: DocumentContext): Promise<DocumentInitialPro
 };
 
 const CustomDocument = (): JSX.Element => {
-    const themeColor = useColorModeValue('bg.light.primary', 'bg.dark.primary');
-
     return (
         <Html lang="nb-NO">
             <Head>
                 <meta name="robots" content="follow, index" />
                 <meta name="msapplication-TileColor" content="#603cba" />
-                <meta name="theme-color" content={themeColor} />
                 <meta property="og:type" content="website" />
                 <meta name="apple-mobile-web-app-capable" content="yes" />
-                <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+                <meta name="apple-mobile-web-app-status-bar-style" content="black" />
 
                 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
                 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />


### PR DESCRIPTION
Fikset `<meta name="theme-color">` 🎨 sånn at fargen endrer seg med om man bruker dark mode 🌚 eller ikke 🙅🏻‍♂️. Siden hvit tekst på hvit bakgrunn er vanskelig å lese 🧐, så er har light mode samme farge som `<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />` 🤷🏻‍♂️

Demo 🎥:

https://user-images.githubusercontent.com/32321558/187151397-b95520c3-f0f8-40be-bec7-e075779b6e1a.mp4


