### PR TITLE
🐛 Fix typo in BACKEND_URL

### DIFF
--- a/frontend/src/pages/tilbakemeldinger/index.tsx
+++ b/frontend/src/pages/tilbakemeldinger/index.tsx
@@ -70,7 +70,7 @@ const FeedbackPage = ({ feedbacks }: Props) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-    const backendUrl = process.env.NEXT_PUBLIC_BACEND_URL ?? 'http://localhost:8080';
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL ?? 'http://localhost:8080';
     const adminKey = process.env.ADMIN_KEY;
     if (!adminKey) throw new Error('No ADMIN_KEY defined.');
 


### PR DESCRIPTION
Hadde typo, så greia redirecta bare `/profile` hele tiden. 🗿