### PR TITLE
Fixed unique slug generation

### DIFF
--- a/cms/sanity.json
+++ b/cms/sanity.json
@@ -25,6 +25,10 @@
         {
             "name": "part:@sanity/base/schema",
             "path": "./schemas/schema"
+        },
+        {
+            "implements": "part:@sanity/base/document-actions/resolver",
+            "path": "./src/resolveDocumentActions.js"
         }
     ]
 }

--- a/cms/schemas/Happening.js
+++ b/cms/schemas/Happening.js
@@ -1,3 +1,5 @@
+import sanityClient from 'part:@sanity/base/client';
+
 export default {
     name: 'happening',
     title: 'Arrangement',
@@ -21,9 +23,19 @@ export default {
             name: 'slug',
             title: 'Slug (lenke)',
             validation: (Rule) => Rule.required(),
+            description: 'Unik identifikator for arrangementet. Bruk "Generate"-knappen! Ikke skriv inn på egenhånd!',
             type: 'slug',
+            readOnly: ({ document }) => document?.publishedOnce,
             options: {
                 source: 'title',
+                slugify: (input) => {
+                    const slug = input.toLowerCase().replace(/\s+/g, '-').replaceAll('/', '-').slice(0, 200);
+                    const query = 'count(*[_type == "happening" && slug.current == $slug]{_id})';
+                    const params = { slug };
+                    return sanityClient
+                        .fetch(query, params)
+                        .then((count) => (count > 0 ? `${slug}-${count + 1}` : slug));
+                },
             },
         },
         {

--- a/cms/src/resolveDocumentActions.js
+++ b/cms/src/resolveDocumentActions.js
@@ -1,0 +1,6 @@
+import defaultResolve, { PublishAction } from 'part:@sanity/base/document-actions';
+import SetAndPublishAction from './setAndPublishAction';
+
+export default function resolveDocumentActions(props) {
+    return defaultResolve(props).map((Action) => (Action === PublishAction ? SetAndPublishAction : Action));
+}

--- a/cms/src/setAndPublishAction.js
+++ b/cms/src/setAndPublishAction.js
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+import { useDocumentOperation } from '@sanity/react-hooks';
+
+export default function SetAndPublishAction(props) {
+    const { patch, publish } = useDocumentOperation(props.id, props.type);
+    const [isPublishing, setIsPublishing] = useState(false);
+
+    useEffect(() => {
+        // if the isPublishing state was set to true and the draft has changed
+        // to become `null` the document has been published
+        if (isPublishing && !props.draft) {
+            setIsPublishing(false);
+        }
+    }, [props.draft]);
+
+    return {
+        disabled: publish.disabled,
+        label: isPublishing ? 'Publishing…' : 'Publish',
+        onHandle: () => {
+            // This will update the button text
+            setIsPublishing(true);
+
+            // Set publishedAt to current date and time
+            patch.execute([{ set: { publishedOnce: true } }]);
+
+            // Perform the publish
+            publish.execute();
+
+            // Signal that the action is completed
+            props.onComplete();
+        },
+    };
+}


### PR DESCRIPTION
Har fikset slik at generate-knappen generer en gyldig slug som også er unik (selvom det finnes like fra før).

Gjorde det også slik at man kun kan edite dette feltet før happeningen er publisert. Når en happening er publisert 1 gang, så vil feltet bli view-only.
Dette har *ikke* tilbakevirkende effekt, så enten kan vi migrere dataen, publishe alt på nytt, eller bare ignorere problemet :)
