### PR TITLE
✨ Move registrations list to /event

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,4 +8,3 @@ SENDGRID_API_KEY=key_here
 # Optional feature toggles.
 # These do not need to be defined.
 SEND_EMAIL_REGISTRATION=false   # default is false
-SEND_EMAIL_HAPPENING=true       # default is true 

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -22,7 +22,6 @@ services:
       ADMIN_KEY: ${ADMIN_KEY:?Must specify ADMIN_KEY in .env file or environment.}
       SENDGRID_API_KEY:
       SEND_EMAIL_REGISTRATION:
-      SEND_EMAIL_HAPPENING:
       TEST_MIGRATION:
       PORT:
 

--- a/backend/src/main/kotlin/no/uib/echo/Application.kt
+++ b/backend/src/main/kotlin/no/uib/echo/Application.kt
@@ -52,9 +52,10 @@ fun Application.module() {
     DatabaseHandler(dev, testMigration, databaseUrl, mbMaxPoolSize).init()
 
     configureRouting(
-        adminKey,
-        sendGridApiKey,
-        dev,
-        FeatureToggles(sendEmailReg = sendEmailReg, rateLimit = true, verifyRegs = verifyRegs)
+        adminKey = adminKey,
+        featureToggles = FeatureToggles(sendEmailReg = sendEmailReg, rateLimit = true, verifyRegs = verifyRegs),
+        dev = dev,
+        disableJwtAuth = false,
+        sendGridApiKey = sendGridApiKey,
     )
 }

--- a/backend/src/main/kotlin/no/uib/echo/Application.kt
+++ b/backend/src/main/kotlin/no/uib/echo/Application.kt
@@ -12,7 +12,6 @@ import kotlin.Exception
 
 data class FeatureToggles(
     val sendEmailReg: Boolean,
-    val sendEmailHap: Boolean,
     val rateLimit: Boolean,
     val verifyRegs: Boolean
 )
@@ -40,7 +39,6 @@ fun Application.module() {
     val databaseUrl = URI(environment.config.property("ktor.databaseUrl").getString())
     val mbMaxPoolSize = environment.config.propertyOrNull("ktor.maxPoolSize")?.getString()
     val sendEmailReg = environment.config.property("ktor.sendEmailRegistration").getString().toBooleanStrict()
-    val sendEmailHap = environment.config.property("ktor.sendEmailHappening").getString().toBooleanStrict()
     val verifyRegs = environment.config.property("ktor.verifyRegs").getString().toBooleanStrict()
     val maybeSendGridApiKey = environment.config.propertyOrNull("ktor.sendGridApiKey")?.getString()
     val sendGridApiKey = when (maybeSendGridApiKey.isNullOrEmpty()) {
@@ -48,8 +46,8 @@ fun Application.module() {
         false -> maybeSendGridApiKey
     }
 
-    if (sendGridApiKey == null && !dev && (sendEmailReg || sendEmailHap))
-        throw Exception("SENDGRID_API_KEY not defined in non-dev environment, with SEND_EMAIL_REGISTRATION = $sendEmailReg and SEND_EMAIL_HAPPENING = $sendEmailHap.")
+    if (sendGridApiKey == null && !dev && sendEmailReg)
+        throw Exception("SENDGRID_API_KEY not defined in non-dev environment, with SEND_EMAIL_REGISTRATION = $sendEmailReg.")
 
     DatabaseHandler(dev, testMigration, databaseUrl, mbMaxPoolSize).init()
 
@@ -57,6 +55,6 @@ fun Application.module() {
         adminKey,
         sendGridApiKey,
         dev,
-        FeatureToggles(sendEmailReg = sendEmailReg, sendEmailHap = sendEmailHap, rateLimit = true, verifyRegs = verifyRegs)
+        FeatureToggles(sendEmailReg = sendEmailReg, rateLimit = true, verifyRegs = verifyRegs)
     )
 }

--- a/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
+++ b/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
@@ -3,17 +3,24 @@ package no.uib.echo
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import no.uib.echo.schema.Answer
+import no.uib.echo.schema.Degree
 import no.uib.echo.schema.Feedback
+import no.uib.echo.schema.HAPPENING_TYPE
 import no.uib.echo.schema.Happening
+import no.uib.echo.schema.HappeningJson
 import no.uib.echo.schema.Registration
 import no.uib.echo.schema.SpotRange
+import no.uib.echo.schema.SpotRangeJson
 import no.uib.echo.schema.StudentGroup
 import no.uib.echo.schema.StudentGroupMembership
 import no.uib.echo.schema.User
+import no.uib.echo.schema.UserJson
 import org.flywaydb.core.Flyway
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.batchInsert
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.joda.time.DateTime
 import java.net.URI
 
 private const val DEFAULT_DEV_POOL_SIZE = 10
@@ -29,10 +36,9 @@ class DatabaseHandler(
     private val dbUrl = "jdbc:postgresql://${dbUrl.host}:${dbPort}${dbUrl.path}"
     private val dbUsername = dbUrl.userInfo.split(":")[0]
     private val dbPassword = dbUrl.userInfo.split(":")[1]
-    private val maxPoolSize =
-        if (dev) DEFAULT_DEV_POOL_SIZE
-        else if (mbMaxPoolSize == null) DEFAULT_PROD_POOL_SIZE
-        else mbMaxPoolSize.toIntOrNull() ?: DEFAULT_PROD_POOL_SIZE
+    private val maxPoolSize = if (dev) DEFAULT_DEV_POOL_SIZE
+    else if (mbMaxPoolSize == null) DEFAULT_PROD_POOL_SIZE
+    else mbMaxPoolSize.toIntOrNull() ?: DEFAULT_PROD_POOL_SIZE
 
     private fun dataSource(): HikariDataSource {
         return HikariDataSource(
@@ -65,18 +71,90 @@ class DatabaseHandler(
             try {
                 transaction(conn) {
                     SchemaUtils.create(
-                        Happening,
-                        Registration,
-                        Answer,
-                        SpotRange,
-                        User,
-                        StudentGroup,
-                        StudentGroupMembership,
-                        Feedback
+                        Happening, Registration, Answer, SpotRange, User, Feedback, StudentGroup, StudentGroupMembership
                     )
+
+                    // Insert test data
+                    val studentGroups = listOf("webkom", "bedkom", "tilde")
+                    val users = listOf(
+                        UserJson(
+                            "andreas.bakseter@student.uib.no", "halla@bruh.com", 3, Degree.DTEK, listOf("tilde")
+                        )
+                    )
+                    val happenings = listOf(
+                        HappeningJson(
+                            "bedriftspresentasjon-med-bekk",
+                            "Bedpres med Bekk",
+                            "021-05-06T16:46+01:00",
+                            "2030-03-09T16:15+01:00",
+                            spotRanges = listOf(
+                                SpotRangeJson(
+                                    11, 1, 2
+                                ),
+                                SpotRangeJson(
+                                    9, 3, 5
+                                )
+                            ),
+                            HAPPENING_TYPE.BEDPRES,
+                            "bedkom@echo.uib.no",
+                            studentGroups[1]
+                        ),
+                        HappeningJson(
+                            "fest-med-tilde",
+                            "Fest med Tilde!",
+                            "2021-05-06T16:46+01:00",
+                            "2030-06-02T14:20+01:00",
+                            spotRanges = listOf(
+                                SpotRangeJson(
+                                    20, 1, 5
+                                )
+                            ),
+                            HAPPENING_TYPE.EVENT,
+                            "tilde@echo.uib.no",
+                            studentGroups[2]
+                        )
+                    )
+
+                    StudentGroup.batchInsert(studentGroups) {
+                        this[StudentGroup.name] = it
+                    }
+
+                    User.batchInsert(users) {
+                        this[User.email] = it.email
+                        this[User.alternateEmail] = it.alternateEmail
+                        this[User.degree] = it.degree.toString()
+                        this[User.degreeYear] = it.degreeYear
+                    }
+
+                    for (user in users) {
+                        StudentGroupMembership.batchInsert(user.memberships) {
+                            this[StudentGroupMembership.studentGroupName] = it
+                            this[StudentGroupMembership.userEmail] = user.email
+                        }
+                    }
+
+                    Happening.batchInsert(happenings) {
+                        this[Happening.slug] = it.slug
+                        this[Happening.title] = it.title
+                        this[Happening.happeningType] = it.type.toString()
+                        this[Happening.registrationDate] = DateTime(it.registrationDate)
+                        this[Happening.happeningDate] = DateTime(it.happeningDate)
+                        this[Happening.organizerEmail] = it.organizerEmail.lowercase()
+                        this[Happening.regVerifyToken] = it.slug
+                        this[Happening.studentGroupName] = it.studentGroupName.lowercase()
+                    }
+
+                    for (happening in happenings) {
+                        SpotRange.batchInsert(happening.spotRanges) {
+                            this[SpotRange.happeningSlug] = happening.slug
+                            this[SpotRange.spots] = it.spots
+                            this[SpotRange.minDegreeYear] = it.minDegreeYear
+                            this[SpotRange.maxDegreeYear] = it.maxDegreeYear
+                        }
+                    }
                 }
             } catch (e: Exception) {
-                println("Assuming all tables already exists, and continuing anyway.")
+                System.err.println("Test data already inserted.")
             }
         }
     }

--- a/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
+++ b/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
@@ -76,6 +76,8 @@ class DatabaseHandler(
                         Happening, Registration, Answer, SpotRange, User, Feedback, StudentGroup, StudentGroupMembership
                     )
                 }
+
+                insertTestData()
             } catch (e: Exception) {
                 System.err.println("Error creating tables.")
             }

--- a/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
+++ b/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
@@ -18,6 +18,8 @@ import no.uib.echo.schema.UserJson
 import org.flywaydb.core.Flyway
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.StdOutSqlLogger
+import org.jetbrains.exposed.sql.addLogger
 import org.jetbrains.exposed.sql.batchInsert
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.joda.time.DateTime
@@ -73,89 +75,98 @@ class DatabaseHandler(
                     SchemaUtils.create(
                         Happening, Registration, Answer, SpotRange, User, Feedback, StudentGroup, StudentGroupMembership
                     )
-
-                    // Insert test data
-                    val studentGroups = listOf("webkom", "bedkom", "tilde")
-                    val users = listOf(
-                        UserJson(
-                            "andreas.bakseter@student.uib.no", "halla@bruh.com", 3, Degree.DTEK, listOf("tilde")
-                        )
-                    )
-                    val happenings = listOf(
-                        HappeningJson(
-                            "bedriftspresentasjon-med-bekk",
-                            "Bedpres med Bekk",
-                            "021-05-06T16:46+01:00",
-                            "2030-03-09T16:15+01:00",
-                            spotRanges = listOf(
-                                SpotRangeJson(
-                                    11, 1, 2
-                                ),
-                                SpotRangeJson(
-                                    9, 3, 5
-                                )
-                            ),
-                            HAPPENING_TYPE.BEDPRES,
-                            "bedkom@echo.uib.no",
-                            studentGroups[1]
-                        ),
-                        HappeningJson(
-                            "fest-med-tilde",
-                            "Fest med Tilde!",
-                            "2021-05-06T16:46+01:00",
-                            "2030-06-02T14:20+01:00",
-                            spotRanges = listOf(
-                                SpotRangeJson(
-                                    20, 1, 5
-                                )
-                            ),
-                            HAPPENING_TYPE.EVENT,
-                            "tilde@echo.uib.no",
-                            studentGroups[2]
-                        )
-                    )
-
-                    StudentGroup.batchInsert(studentGroups) {
-                        this[StudentGroup.name] = it
-                    }
-
-                    User.batchInsert(users) {
-                        this[User.email] = it.email
-                        this[User.alternateEmail] = it.alternateEmail
-                        this[User.degree] = it.degree.toString()
-                        this[User.degreeYear] = it.degreeYear
-                    }
-
-                    for (user in users) {
-                        StudentGroupMembership.batchInsert(user.memberships) {
-                            this[StudentGroupMembership.studentGroupName] = it
-                            this[StudentGroupMembership.userEmail] = user.email
-                        }
-                    }
-
-                    Happening.batchInsert(happenings) {
-                        this[Happening.slug] = it.slug
-                        this[Happening.title] = it.title
-                        this[Happening.happeningType] = it.type.toString()
-                        this[Happening.registrationDate] = DateTime(it.registrationDate)
-                        this[Happening.happeningDate] = DateTime(it.happeningDate)
-                        this[Happening.organizerEmail] = it.organizerEmail.lowercase()
-                        this[Happening.regVerifyToken] = it.slug
-                        this[Happening.studentGroupName] = it.studentGroupName.lowercase()
-                    }
-
-                    for (happening in happenings) {
-                        SpotRange.batchInsert(happening.spotRanges) {
-                            this[SpotRange.happeningSlug] = happening.slug
-                            this[SpotRange.spots] = it.spots
-                            this[SpotRange.minDegreeYear] = it.minDegreeYear
-                            this[SpotRange.maxDegreeYear] = it.maxDegreeYear
-                        }
-                    }
                 }
             } catch (e: Exception) {
-                System.err.println("Test data already inserted.")
+                System.err.println("Error creating tables.")
             }
+        }
+    }
+
+    fun insertTestData() {
+        val studentGroups = listOf("webkom", "bedkom", "tilde")
+        val users = listOf(
+            UserJson(
+                "andreas.bakseter@student.uib.no", "halla@bruh.com", 3, Degree.DTEK, listOf("tilde")
+            )
+        )
+        val happenings = listOf(
+            HappeningJson(
+                "bedriftspresentasjon-med-bekk",
+                "Bedpres med Bekk",
+                "021-05-06T16:46+01:00",
+                "2030-03-09T16:15+01:00",
+                spotRanges = listOf(
+                    SpotRangeJson(
+                        11, 1, 2
+                    ),
+                    SpotRangeJson(
+                        9, 3, 5
+                    )
+                ),
+                HAPPENING_TYPE.BEDPRES,
+                "bedkom@echo.uib.no",
+                studentGroups[1]
+            ),
+            HappeningJson(
+                "fest-med-tilde",
+                "Fest med Tilde!",
+                "2021-05-06T16:46+01:00",
+                "2030-06-02T14:20+01:00",
+                spotRanges = listOf(
+                    SpotRangeJson(
+                        20, 1, 5
+                    )
+                ),
+                HAPPENING_TYPE.EVENT,
+                "tilde@echo.uib.no",
+                studentGroups[2]
+            )
+        )
+
+        try {
+            transaction {
+                addLogger(StdOutSqlLogger)
+
+                StudentGroup.batchInsert(studentGroups) {
+                    this[StudentGroup.name] = it
+                }
+
+                User.batchInsert(users) {
+                    this[User.email] = it.email
+                    this[User.alternateEmail] = it.alternateEmail
+                    this[User.degree] = it.degree.toString()
+                    this[User.degreeYear] = it.degreeYear
+                }
+
+                for (user in users) {
+                    StudentGroupMembership.batchInsert(user.memberships) {
+                        this[StudentGroupMembership.studentGroupName] = it
+                        this[StudentGroupMembership.userEmail] = user.email
+                    }
+                }
+
+                Happening.batchInsert(happenings) {
+                    this[Happening.slug] = it.slug
+                    this[Happening.title] = it.title
+                    this[Happening.happeningType] = it.type.toString()
+                    this[Happening.registrationDate] = DateTime(it.registrationDate)
+                    this[Happening.happeningDate] = DateTime(it.happeningDate)
+                    this[Happening.organizerEmail] = it.organizerEmail.lowercase()
+                    this[Happening.regVerifyToken] = it.slug
+                    this[Happening.studentGroupName] = it.studentGroupName.lowercase()
+                }
+
+                for (happening in happenings) {
+                    SpotRange.batchInsert(happening.spotRanges) {
+                        this[SpotRange.happeningSlug] = happening.slug
+                        this[SpotRange.spots] = it.spots
+                        this[SpotRange.minDegreeYear] = it.minDegreeYear
+                        this[SpotRange.maxDegreeYear] = it.maxDegreeYear
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            System.err.println("Error inserting test data.")
         }
     }
 }

--- a/backend/src/main/kotlin/no/uib/echo/Email.kt
+++ b/backend/src/main/kotlin/no/uib/echo/Email.kt
@@ -15,10 +15,8 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
-import no.uib.echo.plugins.Routing
 import no.uib.echo.schema.HAPPENING_TYPE
 import no.uib.echo.schema.Happening
-import no.uib.echo.schema.HappeningJson
 import no.uib.echo.schema.RegistrationJson
 import org.jetbrains.exposed.sql.StdOutSqlLogger
 import org.jetbrains.exposed.sql.addLogger
@@ -108,33 +106,6 @@ suspend fun sendConfirmationEmail(
                     registration = registration
                 ),
                 if (waitListSpot != null) Template.CONFIRM_WAIT else Template.CONFIRM_REG,
-                sendGridApiKey
-            )
-        }
-    } catch (e: IOException) {
-        e.printStackTrace()
-    }
-}
-
-suspend fun sendRegsLinkEmail(sendGridApiKey: String, happening: HappeningJson, regsLink: String) {
-    val hapTypeLiteral = when (happening.type) {
-        HAPPENING_TYPE.EVENT ->
-            "arrangementet"
-        HAPPENING_TYPE.BEDPRES ->
-            "bedriftspresentasjonen"
-    }
-
-    try {
-        withContext(Dispatchers.IO) {
-            sendEmail(
-                "webkom@echo.uib.no",
-                happening.organizerEmail,
-                SendGridTemplate(
-                    happening.title,
-                    "https://echo.uib.no/${Routing.registrationRoute}/$regsLink",
-                    hapTypeLiteral
-                ),
-                Template.REGS_LINK,
                 sendGridApiKey
             )
         }

--- a/backend/src/main/kotlin/no/uib/echo/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/uib/echo/plugins/Routing.kt
@@ -959,13 +959,20 @@ object Routing {
 
         put("/feedback") {
             try {
+                val email = call.principal<JWTPrincipal>()?.payload?.getClaim("email")?.asString()?.lowercase()
+
+                if (email !in getGroupMembers("webkom")) {
+                    call.respond(HttpStatusCode.Forbidden)
+                    return@put
+                }
+
                 val feedback = call.receive<FeedbackResponseJson>()
 
                 transaction {
                     addLogger(StdOutSqlLogger)
 
                     Feedback.update({ Feedback.id eq feedback.id }) {
-                        it[email] = feedback.email
+                        it[Feedback.email] = feedback.email
                         it[name] = feedback.name
                         it[message] = feedback.message
                         it[isRead] = feedback.isRead

--- a/backend/src/main/kotlin/no/uib/echo/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/uib/echo/plugins/Routing.kt
@@ -91,6 +91,7 @@ import org.joda.time.DateTime
 import java.net.URL
 import java.net.URLDecoder
 import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
 
 fun Application.configureRouting(
     adminKey: String,
@@ -102,7 +103,9 @@ fun Application.configureRouting(
     val admin = "admin"
 
     install(ContentNegotiation) {
-        json()
+        json(Json {
+            ignoreUnknownKeys = true
+        })
     }
 
     install(Authentication) {

--- a/backend/src/main/kotlin/no/uib/echo/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/uib/echo/plugins/Routing.kt
@@ -30,6 +30,7 @@ import io.ktor.server.routing.routing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import no.uib.echo.FeatureToggles
 import no.uib.echo.Response
 import no.uib.echo.isEmailValid
@@ -91,7 +92,6 @@ import org.joda.time.DateTime
 import java.net.URL
 import java.net.URLDecoder
 import java.util.concurrent.TimeUnit
-import kotlinx.serialization.json.Json
 
 fun Application.configureRouting(
     adminKey: String,
@@ -103,9 +103,11 @@ fun Application.configureRouting(
     val admin = "admin"
 
     install(ContentNegotiation) {
-        json(Json {
-            ignoreUnknownKeys = true
-        })
+        json(
+            Json {
+                ignoreUnknownKeys = true
+            }
+        )
     }
 
     install(Authentication) {

--- a/backend/src/main/kotlin/no/uib/echo/schema/StudentGroup.kt
+++ b/backend/src/main/kotlin/no/uib/echo/schema/StudentGroup.kt
@@ -1,7 +1,13 @@
 package no.uib.echo.schema
 
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.StdOutSqlLogger
 import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.addLogger
+import org.jetbrains.exposed.sql.or
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
 
 object StudentGroup : Table("student_group") {
     val name: Column<String> = text("group_name").check("valid_student_group") {
@@ -16,4 +22,15 @@ object StudentGroupMembership : Table("student_group_membership") {
     val studentGroupName: Column<String> = text("student_group_name") references StudentGroup.name
 
     override val primaryKey: PrimaryKey = PrimaryKey(studentGroupName, userEmail)
+}
+
+fun getGroupMembers(group: String): List<String> {
+    return transaction {
+        addLogger(StdOutSqlLogger)
+
+        StudentGroupMembership.select {
+            StudentGroupMembership.studentGroupName eq group.lowercase() or
+                (StudentGroupMembership.studentGroupName eq "webkom")
+        }.toList().map { it[StudentGroupMembership.userEmail].lowercase() }
+    }
 }

--- a/backend/src/main/kotlin/no/uib/echo/schema/User.kt
+++ b/backend/src/main/kotlin/no/uib/echo/schema/User.kt
@@ -10,6 +10,7 @@ data class UserJson(
     val alternateEmail: String? = null,
     val degreeYear: Int,
     val degree: Degree,
+    val memberships: List<String> = emptyList()
 )
 
 object User : Table() {

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -10,7 +10,6 @@ ktor {
     # Default values
     testMigration = false
     sendEmailRegistration = false
-    sendEmailHappening = true
     verifyRegs = true
 
     # Essential variables (crashes if not defined)
@@ -21,7 +20,6 @@ ktor {
     dev = ${?DEV}
     testMigration = ${?TEST_MIGRATION}
     sendEmailRegistration = ${?SEND_EMAIL_REGISTRATION}
-    sendEmailHappening = ${?SEND_EMAIL_HAPPENING}
     verifyRegs = ${?VERIFY_REGS}
     sendGridApiKey = ${?SENDGRID_API_KEY}
     maxPoolSize = ${?MAX_POOL_SIZE}

--- a/backend/src/main/resources/db/migration/V20__Event_regs_list.sql
+++ b/backend/src/main/resources/db/migration/V20__Event_regs_list.sql
@@ -1,0 +1,9 @@
+ALTER TABLE happening
+    ADD COLUMN student_group_name TEXT;
+
+ALTER TABLE happening
+    ADD CONSTRAINT fk_student_group_name_____osv
+        FOREIGN KEY (student_group_name) REFERENCES student_group (name);
+
+ALTER TABLE happening
+    DROP COLUMN registrations_link;

--- a/backend/src/main/resources/db/migration/V20__Event_regs_list.sql
+++ b/backend/src/main/resources/db/migration/V20__Event_regs_list.sql
@@ -2,7 +2,7 @@ ALTER TABLE happening
     ADD COLUMN student_group_name TEXT;
 
 ALTER TABLE happening
-    ADD CONSTRAINT fk_student_group_name_____osv
+    ADD CONSTRAINT fk_happening_student_group_name__group_name
         FOREIGN KEY (student_group_name) REFERENCES student_group (name);
 
 ALTER TABLE happening

--- a/cms/schemas/Happening.js
+++ b/cms/schemas/Happening.js
@@ -137,8 +137,7 @@ export default {
         },
         {
             name: 'contactEmail',
-            title: 'Hvilken email skal liste over påmeldte sendes til, og hvem kan man kontakte ved f.eks. avmelding?',
-            description: '⚠️ Liste over påmeldte vil bli sendt til denne mailen! ⚠️',
+            title: 'Hvem kan man kontakte ved f.eks. avmelding?',
             validation: (Rule) =>
                 Rule.custom((contactEmail, context) =>
                     (typeof context.document.registrationDate !== 'undefined' ||
@@ -187,6 +186,22 @@ export default {
                     ],
                 },
             ],
+        },
+        {
+            name: 'studentGroupName',
+            title: 'Navn på studentgruppe',
+            type: 'string',
+            validation: (Rule) => Rule.required(),
+            options: {
+                list: [
+                    { title: 'Hovedstyret', value: 'hovedstyret' },
+                    { title: 'Bedkom', value: 'bedkom' },
+                    { title: 'Webkom', value: 'webkom' },
+                    { title: 'Gnist', value: 'gnist' },
+                    { title: 'Tilde', value: 'tilde' },
+                ],
+                layout: 'dropdown',
+            },
         },
     ],
 };

--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -40,7 +40,7 @@ services:
       - '8080:8080'
     # Check if backend is ready, and insert bedpres for testing.
     healthcheck:
-      test: ['CMD-SHELL', './scripts/submit_happening -t -x $$ADMIN_KEY || exit 1']
+      test: ['CMD-SHELL', 'curl -v http://localhost:8080/status || exit 1']
       interval: 5s
       timeout: 5s
       retries: 5

--- a/frontend/src/components/profile-info.tsx
+++ b/frontend/src/components/profile-info.tsx
@@ -2,7 +2,8 @@ import { useState, useContext } from 'react';
 import { signOut } from 'next-auth/react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm, FormProvider } from 'react-hook-form';
-import { Box, Input, Heading, Text, FormControl, FormLabel, Button } from '@chakra-ui/react';
+import { Box, Input, HStack, Heading, Text, FormControl, FormLabel, Button } from '@chakra-ui/react';
+import firstUpper from '@utils/first-upper';
 import type { ProfileFormValues, UserWithName } from '@api/user';
 import { UserAPI } from '@api/user';
 import { isErrorMessage } from '@utils/error';
@@ -28,6 +29,7 @@ const ProfileInfo = ({ user }: { user: UserWithName }): JSX.Element => {
             alternateEmail: data.alternateEmail,
             degree: data.degree,
             degreeYear: +data.degreeYear,
+            memberships: [],
         });
 
         if (isErrorMessage(res)) {
@@ -92,30 +94,38 @@ const ProfileInfo = ({ user }: { user: UserWithName }): JSX.Element => {
                         defaultValue={user.degreeYear ?? undefined}
                         py="1rem"
                     />
-                    <Button
-                        disabled={profileState.infoState !== 'edited'}
-                        isLoading={profileState.infoState === 'saving'}
-                        type="submit"
-                        form="profile-form"
-                        mr={3}
-                        colorScheme="teal"
-                    >
-                        {profileState.infoState === 'saved'
-                            ? isNorwegian
-                                ? 'Endringer lagret!'
-                                : 'Changes saved!'
-                            : isNorwegian
-                            ? 'Lagre endringer'
-                            : 'Save changes'}
-                    </Button>
-                    <Button onClick={() => void signOut()} colorScheme="red">
-                        {isNorwegian ? 'Logg ut' : 'Log out'}
-                    </Button>
-                    {profileState.errorMessage && (
-                        <Text fontWeight="bold" color="red" pt="3">
-                            {profileState.errorMessage}
-                        </Text>
-                    )}
+                    <Heading size="md" my="0.5rem">
+                        Studentgrupper
+                    </Heading>
+                    <Text data-cy="profile-email" my="0.5rem">
+                        {user.memberships.map((m: string) => firstUpper(m)).join(', ')}
+                    </Text>
+                    <HStack mt={4}>
+                        <Button
+                            disabled={profileState.infoState !== 'edited'}
+                            isLoading={profileState.infoState === 'saving'}
+                            type="submit"
+                            form="profile-form"
+                            mr={3}
+                            colorScheme="teal"
+                        >
+                            {profileState.infoState === 'saved'
+                                ? isNorwegian
+                                    ? 'Endringer lagret!'
+                                    : 'Changes saved!'
+                                : isNorwegian
+                                ? 'Lagre endringer'
+                                : 'Save changes'}
+                        </Button>
+                        <Button onClick={() => void signOut()} colorScheme="red">
+                            {isNorwegian ? 'Logg ut' : 'Log out'}
+                        </Button>
+                        {profileState.errorMessage && (
+                            <Text fontWeight="bold" color="red" pt="3">
+                                {profileState.errorMessage}
+                            </Text>
+                        )}
+                    </HStack>
                 </form>
             </FormProvider>
         </Box>

--- a/frontend/src/components/profile-info.tsx
+++ b/frontend/src/components/profile-info.tsx
@@ -3,7 +3,7 @@ import { signOut } from 'next-auth/react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm, FormProvider } from 'react-hook-form';
 import { Box, Input, HStack, Heading, Text, FormControl, FormLabel, Button } from '@chakra-ui/react';
-import firstUpper from '@utils/first-upper';
+import capitalize from '@utils/capitalize';
 import type { ProfileFormValues, UserWithName } from '@api/user';
 import { UserAPI } from '@api/user';
 import { isErrorMessage } from '@utils/error';
@@ -98,7 +98,7 @@ const ProfileInfo = ({ user }: { user: UserWithName }): JSX.Element => {
                         Studentgrupper
                     </Heading>
                     <Text data-cy="profile-email" my="0.5rem">
-                        {user.memberships.map((m: string) => firstUpper(m)).join(', ')}
+                        {user.memberships.map((m: string) => capitalize(m)).join(', ')}
                     </Text>
                     <HStack mt={4}>
                         <Button

--- a/frontend/src/components/registration-row.tsx
+++ b/frontend/src/components/registration-row.tsx
@@ -26,13 +26,11 @@ import notEmptyOrNull from '@utils/not-empty-or-null';
 interface Props {
     registration: Registration;
     questions: Array<string> | null;
-    link: string;
-    backendUrl: string;
 }
 
 const MotionTr = motion<TableRowProps>(Tr);
 
-const RegistrationRow = ({ registration, questions, link, backendUrl }: Props) => {
+const RegistrationRow = ({ registration, questions }: Props) => {
     const { isOpen, onOpen, onClose } = useDisclosure();
 
     const [deleted, setDeleted] = useState(false);
@@ -49,28 +47,32 @@ const RegistrationRow = ({ registration, questions, link, backendUrl }: Props) =
                 data-cy={`reg-row-${registration.email}`}
                 key={JSON.stringify(registration)}
             >
-                <Td>{registration.email}</Td>
-                <Td>{registration.firstName}</Td>
-                <Td>{registration.lastName}</Td>
-                <Td>{registration.degreeYear}</Td>
+                <Td fontSize="md">{registration.email}</Td>
+                <Td fontSize="md">{registration.firstName}</Td>
+                <Td fontSize="md">{registration.lastName}</Td>
+                <Td fontSize="md">{registration.degreeYear}</Td>
                 {notEmptyOrNull(registration.answers) &&
                     registration.answers.map((ans, index) => (
-                        <Td key={`answer-${index}-${JSON.stringify(ans)}`}>{ans.answer}</Td>
+                        <Td fontSize="md" key={`answer-${index}-${JSON.stringify(ans)}`}>
+                            {ans.answer}
+                        </Td>
                     ))}
                 {!notEmptyOrNull(registration.answers) && notEmptyOrNull(questions) && (
-                    <Td fontStyle="italic">ikke besvart</Td>
+                    <Td fontSize="md" fontStyle="italic">
+                        ikke besvart
+                    </Td>
                 )}
                 {registration.waitList ? (
-                    <Td data-cy="reg-row-waitlist-true" fontWeight="bold" color="red.400">
+                    <Td fontSize="md" data-cy="reg-row-waitlist-true" fontWeight="bold" color="red.400">
                         Ja
                     </Td>
                 ) : (
-                    <Td data-cy="reg-row-waitlist-false" fontWeight="bold" color="green.400">
+                    <Td fontSize="md" data-cy="reg-row-waitlist-false" fontWeight="bold" color="green.400">
                         Nei
                     </Td>
                 )}
                 <Td>
-                    <Button data-cy="delete-button" onClick={onOpen} bg="red.400">
+                    <Button fontSize="sm" data-cy="delete-button" onClick={onOpen} bg="red.400">
                         Slett påmelding
                     </Button>
                 </Td>
@@ -106,9 +108,8 @@ const RegistrationRow = ({ registration, questions, link, backendUrl }: Props) =
                                 bg="green.400"
                                 onClick={async () => {
                                     const { error } = await RegistrationAPI.deleteRegistration(
-                                        link,
+                                        registration.slug,
                                         registration.email,
-                                        backendUrl,
                                     );
 
                                     onClose();

--- a/frontend/src/lib/api/user.ts
+++ b/frontend/src/lib/api/user.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import type { decodeType } from 'typescript-json-decoder';
-import { string, record, union, nil, number } from 'typescript-json-decoder';
+import { string, record, union, nil, number, array } from 'typescript-json-decoder';
 import type { ErrorMessage } from '@utils/error';
 import type { Degree } from '@utils/decoders';
 import { degreeDecoder } from '@utils/decoders';
@@ -18,6 +18,7 @@ const userWithNameDecoder = record({
     name: string,
     degree: union(degreeDecoder, nil),
     degreeYear: union(number, nil),
+    memberships: array(string),
 });
 type UserWithName = decodeType<typeof userWithNameDecoder>;
 
@@ -26,6 +27,7 @@ const userDecoder = record({
     alternateEmail: union(string, nil),
     degree: union(degreeDecoder, nil),
     degreeYear: union(number, nil),
+    memberships: array(string),
 });
 type User = decodeType<typeof userDecoder>;
 

--- a/frontend/src/lib/utils/capitalize.ts
+++ b/frontend/src/lib/utils/capitalize.ts
@@ -1,0 +1,3 @@
+const capitalize = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1);
+
+export default capitalize;

--- a/frontend/src/lib/utils/first-upper.ts
+++ b/frontend/src/lib/utils/first-upper.ts
@@ -1,0 +1,3 @@
+const firstUpper = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1);
+
+export default firstUpper;

--- a/frontend/src/lib/utils/first-upper.ts
+++ b/frontend/src/lib/utils/first-upper.ts
@@ -1,3 +1,0 @@
-const firstUpper = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1);
-
-export default firstUpper;

--- a/frontend/src/pages/api/registration/index.ts
+++ b/frontend/src/pages/api/registration/index.ts
@@ -1,0 +1,71 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from 'next-auth/jwt';
+import axios from 'axios';
+import { array, string } from 'typescript-json-decoder';
+import { registrationDecoder } from '@api/registration';
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+    const session = await getToken({ req });
+
+    if (session) {
+        const JWT_TOKEN = session.idToken as string;
+        const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL ?? 'http://localhost:8080';
+        const slug = req.query.slug as string;
+
+        if (!session.email || !session.name) {
+            res.status(401).json({ message: 'Du må være logget inn for å se denne siden.' });
+            return;
+        }
+
+        if (req.method === 'GET') {
+            try {
+                const { data, status } = await axios.get(`${BACKEND_URL}/registration/${slug}?json=y`, {
+                    headers: {
+                        Authorization: `Bearer ${JWT_TOKEN}`,
+                    },
+                    validateStatus: (statusCode: number) => statusCode < 500,
+                });
+
+                if (status === 200) {
+                    res.status(200).json(array(registrationDecoder)(data));
+                    return;
+                }
+
+                res.status(401).json({ message: JSON.stringify(data) });
+                return;
+            } catch {
+                res.status(500).json({ message: 'Noe gikk galt. Prøv igjen senere.' });
+                return;
+            }
+        }
+
+        if (req.method === 'DELETE') {
+            try {
+                const email = req.query.email as string;
+                const { data, status } = await axios.delete(`${BACKEND_URL}/registration/${slug}/${email}`, {
+                    headers: {
+                        Authorization: `Bearer ${JWT_TOKEN}`,
+                    },
+                    validateStatus: (statusCode: number) => statusCode < 500,
+                });
+
+                if (status === 200) {
+                    res.status(200).json(string(data));
+                    return;
+                }
+
+                res.status(401).json({ message: 'Du har ikke tilgang til denne siden.' });
+                return;
+            } catch {
+                res.status(500).json({ message: 'Noe gikk galt. Prøv igjen senere.' });
+                return;
+            }
+        }
+
+        res.status(405).json({ message: 'Metode ikke tillatt.' });
+    }
+
+    res.status(401).json({ message: 'Du har ikke tilgang til denne siden.' });
+};
+
+export default handler;

--- a/frontend/src/pages/api/user/index.ts
+++ b/frontend/src/pages/api/user/index.ts
@@ -39,6 +39,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
                         alternateEmail: null,
                         degreeYear: null,
                         degree: null,
+                        memberships: [],
                     };
 
                     res.status(200).end(JSON.stringify(user));
@@ -51,6 +52,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
                     alternateEmail: response.data.alternateEmail ?? null,
                     degree: response.data.degree ?? null,
                     degreeYear: response.data.degreeYear ?? null,
+                    memberships: response.data.memberships ?? [],
                 };
 
                 res.status(200).end(JSON.stringify(user));
@@ -67,6 +69,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
                 alternateEmail: req.body.alternateEmail,
                 degree: req.body.degree,
                 degreeYear: req.body.degreeYear,
+                memberships: [],
             };
 
             try {


### PR DESCRIPTION
### TL;DR: flyttet påmeldingslister til hvert enkelt arrangement, som bare er synlig om man er med i riktig undergruppe.

- Flyttet påmeldingslister til `/event`.
- Lagt til en kolonne `student_group_name` som sier hvem som arrangerer.
- Fjernet at det blir sendt mail når et nytt arrangement blir laget.
- Om man kjører lokalt, seeder vi database med masse testdata i stedet for å bruke et skript.
- Laget endepunkter for å hente/slette påmeldinger i frontend-API, som sender med Feide-email til backend, og da sjekker om denne emailen tilhører en studentgruppe. Samme som `/tilbakemeldinger`. Vi må legge inn alle mailene manuelt for at personer i studengruppene får tilgang.

## NB :rotating_light: ikke merge
Trengs fortsatt å oppdatere webhooks fra Sanity slik at man får inn arrangør for alle happenings. Slenger bare den her ut nå om noen vil se på den. Sikkert noe småtteri som må fikses.