### PR TITLE
🐛 Fix various job advert issues

### DIFF
--- a/cms/schemas/JobAdvert.js
+++ b/cms/schemas/JobAdvert.js
@@ -1,3 +1,5 @@
+import slugify from 'slugify';
+
 export default {
     name: 'jobAdvert',
     title: 'Stillingsannonse',
@@ -26,10 +28,11 @@ export default {
         {
             name: 'slug',
             title: 'Slug (link)',
-            validation: (Rule) => Rule.required(),
+            description: 'Unik identifikator for innlegget. Bruk "Generate"-knappen! Ikke skriv inn på egenhånd!',
             type: 'slug',
             options: {
-                source: 'companyName',
+                source: 'title',
+                slugify: (input) => slugify(input, { remove: /[*+~.()'"!:@]/g, lower: true, strict: true }),
             },
         },
         {
@@ -81,7 +84,13 @@ export default {
         {
             name: 'degreeYears',
             title: 'Aktuelle årstrinn',
-            validation: (Rule) => Rule.required().unique(),
+            validation: (Rule) => [
+                Rule.custom((degreeYears) =>
+                    degreeYears.every((year) => year >= 1 && year <= 5) ? true : 'Alle årstrinn må være mellom 1 og 5',
+                )
+                    .required()
+                    .unique(),
+            ],
             type: 'array',
             of: [{ type: 'number' }],
         },
@@ -89,10 +98,7 @@ export default {
             name: 'weight',
             title: 'Vekting',
             description: 'Høyere vetkting gir høyere plassering av annonsen.',
-            validation: (Rule) =>
-                Rule.custom((weight) =>
-                    typeof weight === 'undefined' || weight < 0 ? 'Må være et positivt heltall.' : true,
-                ),
+            validation: (Rule) => Rule.required().integer().positive(),
             type: 'number',
         },
     ],

--- a/cms/schemas/JobAdvert.js
+++ b/cms/schemas/JobAdvert.js
@@ -28,7 +28,7 @@ export default {
         {
             name: 'slug',
             title: 'Slug (link)',
-            description: 'Unik identifikator for innlegget. Bruk "Generate"-knappen! Ikke skriv inn på egenhånd!',
+            description: 'Unik identifikator for annonsen. Bruk "Generate"-knappen! Ikke skriv inn på egenhånd!',
             type: 'slug',
             options: {
                 source: 'title',

--- a/frontend/src/components/job-advert-preview.tsx
+++ b/frontend/src/components/job-advert-preview.tsx
@@ -44,7 +44,7 @@ const JobAdvertPreview = ({ jobAdvert }: { jobAdvert: JobAdvert }): JSX.Element 
             _hover={{ borderColor: borderColor }}
             data-testid={jobAdvert.slug}
         >
-            <NextLink href={`/job/${jobAdvert.slug}`} passHref>
+            <NextLink href={`/jobb/${jobAdvert.slug}`} passHref>
                 <LinkOverlay>
                     <SimpleGrid columns={2} alignItems="start">
                         <GridItem>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -125,7 +125,7 @@ const IndexPage = ({
                                 }
                                 entries={jobs}
                                 altText={isNorwegian ? 'Ingen stillingsannonser :(' : 'No job advertisements :('}
-                                linkTo="/job"
+                                linkTo="/jobb"
                                 type="job-advert"
                             />
                         </GridItem>
@@ -184,7 +184,7 @@ export const getStaticProps: GetStaticProps = async () => {
     return {
         props: {
             bedpreses,
-            posts: postsResponse.slice(0, process.env.ENABLE_JOB_ADVERTS?.toLowerCase() === 'true' ? 2 : 3),
+            posts: postsResponse.slice(0, process.env.NEXT_PUBLIC_ENABLE_JOB_ADVERTS?.toLowerCase() === 'true' ? 2 : 3),
             events: events.slice(0, eventLimit),
             jobs: jobsResponse,
             banner: bannerResponse ?? null,

--- a/frontend/src/pages/jobb/[slug].tsx
+++ b/frontend/src/pages/jobb/[slug].tsx
@@ -128,7 +128,7 @@ interface Params extends ParsedUrlQuery {
 }
 
 const getStaticProps: GetStaticProps = async (context) => {
-    if (process.env.ENABLE_JOB_ADVERTS?.toLowerCase() !== 'true') {
+    if (process.env.NEXT_PUBLIC_ENABLE_JOB_ADVERTS?.toLowerCase() !== 'true') {
         return {
             notFound: true,
         };

--- a/frontend/src/pages/jobb/index.tsx
+++ b/frontend/src/pages/jobb/index.tsx
@@ -18,7 +18,7 @@ const JobPage = ({ jobAdverts }: Props) => {
 };
 
 export const getStaticProps: GetStaticProps = async () => {
-    if (process.env.ENABLE_JOB_ADVERTS?.toLowerCase() !== 'true') {
+    if (process.env.NEXT_PUBLIC_ENABLE_JOB_ADVERTS?.toLowerCase() !== 'true') {
         return {
             notFound: true,
         };


### PR DESCRIPTION
- endret fra `/job` til `/jobb` (:norway::norway::norway:)
- la til `slugify` på slug til schema til JobAdvert i CMS
- fikset litt validering på schema til JobAdvert
- endret til riktig navn på miljøvariabel: `ENABLE_JOB_ADVERTS` -> `NEXT_PUBLIC_ENABLE_JOB_ADVERTS`

Nå er stillingsannonser også ute i prod etter forespørsel fra Bedkom :cowboy_hat_face: 