### PR TITLE
💬 Update text & translations for job adverts

### DIFF
--- a/frontend/src/components/job-advert-preview.tsx
+++ b/frontend/src/components/job-advert-preview.tsx
@@ -10,26 +10,19 @@ import {
     useColorModeValue,
     Wrap,
 } from '@chakra-ui/react';
+import { useContext } from 'react';
 import { format } from 'date-fns';
 import NextLink from 'next/link';
 import type { JobAdvert } from '@api/job-advert';
-
-const translateJobType = (jobType: 'fulltime' | 'parttime' | 'internship' | 'summerjob'): string => {
-    switch (jobType) {
-        case 'fulltime':
-            return 'Fulltid';
-        case 'parttime':
-            return 'Deltid';
-        case 'internship':
-            return 'Internship';
-        case 'summerjob':
-            return 'Sommerjobb';
-    }
-};
+import degreeYearText from '@utils/degree-year-text';
+import translateJobType from '@utils/translate-job-type';
+import LanguageContext from 'language-context';
 
 const JobAdvertPreview = ({ jobAdvert }: { jobAdvert: JobAdvert }): JSX.Element => {
     const borderColor = useColorModeValue('bg.light.border', 'bg.dark.border');
     const bgColor = useColorModeValue('bg.light.tertiary', 'bg.dark.tertiary');
+
+    const isNorwegian = useContext(LanguageContext);
 
     return (
         <LinkBox
@@ -53,7 +46,7 @@ const JobAdvertPreview = ({ jobAdvert }: { jobAdvert: JobAdvert }): JSX.Element 
                             </Text>
                             <Wrap>
                                 <Tag colorScheme="teal" variant="subtle">
-                                    {translateJobType(jobAdvert.jobType)}
+                                    {translateJobType(jobAdvert.jobType, isNorwegian)}
                                 </Tag>
                                 {jobAdvert.locations.map((location: string, index: number) => (
                                     <Tag colorScheme="teal" variant="solid" key={`${location}-${index}`}>
@@ -61,11 +54,7 @@ const JobAdvertPreview = ({ jobAdvert }: { jobAdvert: JobAdvert }): JSX.Element 
                                     </Tag>
                                 ))}
                                 <Tag colorScheme="teal" variant="outline">
-                                    {jobAdvert.degreeYears.length === 1
-                                        ? `${String(jobAdvert.degreeYears[0])}. trinn`
-                                        : `${String(jobAdvert.degreeYears.sort().slice(0, -1).join(', '))} og ${String(
-                                              jobAdvert.degreeYears.slice(-1),
-                                          )} . trinn`}
+                                    {degreeYearText(jobAdvert.degreeYears, isNorwegian)}
                                 </Tag>
                                 <Spacer />
                             </Wrap>
@@ -94,5 +83,4 @@ const JobAdvertPreview = ({ jobAdvert }: { jobAdvert: JobAdvert }): JSX.Element 
     );
 };
 
-export { translateJobType };
 export default JobAdvertPreview;

--- a/frontend/src/lib/utils/degree-year-text.ts
+++ b/frontend/src/lib/utils/degree-year-text.ts
@@ -1,0 +1,45 @@
+const degreeYearTag = (degreeYears: Array<number>, isNorwegian: boolean = true): string => {
+    if (degreeYears.length === 1) {
+        const year = degreeYears[0];
+
+        if (isNorwegian) {
+            return `${String(year)}. trinn`;
+        }
+
+        return `${String(year)}${ordinalSuffix(year)} year`;
+    }
+
+    if (degreeYears.length > 0 && degreeYears.length < 5) {
+        if (isNorwegian) {
+            return `${String(degreeYears.sort().slice(0, -1).join(', '))} og ${String(degreeYears.slice(-1))} . trinn`;
+        }
+
+        // Take into account ordinal suffixes
+        const years = degreeYears.sort().map((year) => `${String(year)}${ordinalSuffix(year)}`);
+
+        return `${years.slice(0, -1).join(', ')} and ${String(years.slice(-1))} year`;
+    }
+
+    return isNorwegian ? 'Alle trinn' : 'All years';
+};
+
+const ordinalSuffix = (i: number): string => {
+    const j = i % 10;
+    const k = i % 100;
+
+    if (j === 1 && k !== 11) {
+        return 'st';
+    }
+
+    if (j === 2 && k !== 12) {
+        return 'nd';
+    }
+
+    if (j === 3 && k !== 13) {
+        return 'rd';
+    }
+
+    return 'th';
+};
+
+export default degreeYearTag;

--- a/frontend/src/lib/utils/translate-job-type.ts
+++ b/frontend/src/lib/utils/translate-job-type.ts
@@ -1,0 +1,17 @@
+const translateJobType = (
+    jobType: 'fulltime' | 'parttime' | 'internship' | 'summerjob',
+    isNorwegian: boolean = true,
+): string => {
+    switch (jobType) {
+        case 'fulltime':
+            return isNorwegian ? 'Fulltid' : 'Full time';
+        case 'parttime':
+            return isNorwegian ? 'Deltid' : 'Part time';
+        case 'internship':
+            return 'Internship';
+        case 'summerjob':
+            return isNorwegian ? 'Sommerjobb' : 'Summer internship';
+    }
+};
+
+export default translateJobType;

--- a/frontend/src/pages/jobb/[slug].tsx
+++ b/frontend/src/pages/jobb/[slug].tsx
@@ -19,10 +19,11 @@ import { JobAdvertAPI } from '@api/job-advert';
 import { isErrorMessage } from '@utils/error';
 import MapMarkdownChakra from '@utils/markdown';
 import IconText from '@components/icon-text';
-import { translateJobType } from '@components/job-advert-preview';
+import translateJobType from '@utils/translate-job-type';
 import ButtonLink from '@components/button-link';
 import LanguageContext from 'language-context';
 import { imgUrlFor } from '@api/sanity';
+import degreeYearText from '@utils/degree-year-text';
 
 interface Props {
     jobAdvert: JobAdvert | null;
@@ -66,31 +67,33 @@ const JobAdvertPage = ({ jobAdvert }: Props): JSX.Element => {
                             <VStack alignItems="left" spacing={3}>
                                 <IconText
                                     icon={RiGalleryUploadLine}
-                                    text={`Publisert: ${format(new Date(jobAdvert._createdAt), 'dd. MMM yyyy', {
-                                        locale: isNorwegian ? nb : enUS,
-                                    })}`}
+                                    text={`${isNorwegian ? 'Publisert' : 'Published'}: ${format(
+                                        new Date(jobAdvert._createdAt),
+                                        'dd. MMM yyyy',
+                                        {
+                                            locale: isNorwegian ? nb : enUS,
+                                        },
+                                    )}`}
                                 />
-                                <IconText icon={BiCategory} text={translateJobType(jobAdvert.jobType)} />
+                                <IconText icon={BiCategory} text={translateJobType(jobAdvert.jobType, isNorwegian)} />
                                 <IconText icon={ImLocation} text={jobAdvert.locations.join(' - ')} />
                                 <IconText
                                     icon={FaUniversity}
-                                    text={
-                                        jobAdvert.degreeYears.length === 1
-                                            ? `${String(jobAdvert.degreeYears[0])}. trinn`
-                                            : `${String(
-                                                  jobAdvert.degreeYears.sort().slice(0, -1).join(', '),
-                                              )} og ${String(jobAdvert.degreeYears.slice(-1))} . trinn`
-                                    }
+                                    text={degreeYearText(jobAdvert.degreeYears, isNorwegian)}
                                 />
                                 <IconText
                                     icon={RiTimeLine}
-                                    text={`Søknadsfrist: ${format(new Date(jobAdvert.deadline), 'dd. MMM yyyy', {
-                                        locale: isNorwegian ? nb : enUS,
-                                    })}`}
+                                    text={`${isNorwegian ? 'Søknadsfrist' : 'Deadline'} : ${format(
+                                        new Date(jobAdvert.deadline),
+                                        'dd. MMM yyyy',
+                                        {
+                                            locale: isNorwegian ? nb : enUS,
+                                        },
+                                    )}`}
                                 />
                                 <Divider />
                                 <ButtonLink w="100%" linkTo={jobAdvert.advertLink} isExternal>
-                                    Søk her!
+                                    {isNorwegian ? 'Søk her!' : 'Apply here!'}
                                 </ButtonLink>
                             </VStack>
                         </GridItem>


### PR DESCRIPTION
- la til alle manglende oversettelser for stillingsannonser
- gjorde sånn at om stillingsannonsen gjelder for alle trinn, så står det 'Alle trinn'. Tidligere listet den opp alle trinnene