### PR TITLE
Revert "🔧 Increase JWT expire to 1 week"

### DIFF
--- a/backend/src/main/kotlin/no/uib/echo/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/uib/echo/plugins/Routing.kt
@@ -124,7 +124,7 @@ fun Application.configureRouting(
 
         val issuer = "https://auth.dataporten.no/openid/jwks"
         val jwkProvider = JwkProviderBuilder(URL(issuer))
-            .cached(10, 24 * 7, TimeUnit.HOURS)
+            .cached(10, 24, TimeUnit.HOURS)
             .rateLimited(10, 1, TimeUnit.MINUTES)
             .build()
 

--- a/frontend/src/pages/api/auth/[...nextauth].ts
+++ b/frontend/src/pages/api/auth/[...nextauth].ts
@@ -3,10 +3,10 @@ import type { NextAuthOptions } from 'next-auth';
 
 export const authOptions: NextAuthOptions = {
     session: {
-        maxAge: 3600 * 24 * 7, // 7 days
+        maxAge: 3600,
     },
     jwt: {
-        maxAge: 3600 * 24 * 7, // 7 days
+        maxAge: 3600,
     },
     callbacks: {
         // eslint-disable-next-line @typescript-eslint/require-await


### PR DESCRIPTION
Reverts echo-webkom/echo-web#371

Backend rejecter tokens lenge før 1 uke av en eller annen merkelig grunn. Det resulterer i at frontend sier du er logget inn mens backend ikke henter ut noe info (aka tom profilside).

Har ingen anelse hvorfor dette skjer, så best å fikse UX med denne PR inntil vi finner ut hvordan vi faktisk forlenger token expire.