### PR TITLE
Add DISABLE_JWT_AUTH option in .env

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,3 +8,4 @@ SENDGRID_API_KEY=key_here
 # Optional feature toggles.
 # These do not need to be defined.
 SEND_EMAIL_REGISTRATION=false   # default is false
+DISABLE_JWT_AUTH=false          # default is false

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       SEND_EMAIL_REGISTRATION:
       TEST_MIGRATION:
       PORT:
+      DISABLE_JWT_AUTH:
 
   database:
     image: postgres:13.8-alpine


### PR DESCRIPTION
Har lagt oppdatert `docker-compose.yaml` og `.env.example` man kan teste visse endepunkter lokalt uten JWT.
