### PR TITLE
Add .vercel to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 .next/
 
 .vscode/
+.vercel


### PR DESCRIPTION
La til `.vercel` i `.gitignore`. Den blir generert dersom man kjører dev-server med vercel (`vercel dev` i stedet for `yarn dev`).
