### PR TITLE
✨ Improve Feide sign in & user handling

### DIFF
--- a/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
+++ b/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
@@ -3,7 +3,6 @@ package no.uib.echo
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import no.uib.echo.schema.Answer
-import no.uib.echo.schema.Degree
 import no.uib.echo.schema.Feedback
 import no.uib.echo.schema.HAPPENING_TYPE
 import no.uib.echo.schema.Happening
@@ -14,7 +13,6 @@ import no.uib.echo.schema.SpotRangeJson
 import no.uib.echo.schema.StudentGroup
 import no.uib.echo.schema.StudentGroupMembership
 import no.uib.echo.schema.User
-import no.uib.echo.schema.UserJson
 import org.flywaydb.core.Flyway
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
@@ -92,11 +90,6 @@ class DatabaseHandler(
 
     private fun insertTestData() {
         val studentGroups = listOf("webkom", "bedkom", "tilde")
-        val users = listOf(
-            UserJson(
-                "andreas.bakseter@student.uib.no", "halla@bruh.com", 3, Degree.DTEK, listOf("tilde")
-            )
-        )
         val happenings = listOf(
             HappeningJson(
                 "bedriftspresentasjon-med-bekk",
@@ -137,20 +130,6 @@ class DatabaseHandler(
 
                 StudentGroup.batchInsert(studentGroups) {
                     this[StudentGroup.name] = it
-                }
-
-                User.batchInsert(users) {
-                    this[User.email] = it.email
-                    this[User.alternateEmail] = it.alternateEmail
-                    this[User.degree] = it.degree.toString()
-                    this[User.degreeYear] = it.degreeYear
-                }
-
-                for (user in users) {
-                    StudentGroupMembership.batchInsert(user.memberships) {
-                        this[StudentGroupMembership.studentGroupName] = it
-                        this[StudentGroupMembership.userEmail] = user.email
-                    }
                 }
 
                 Happening.batchInsert(happenings) {

--- a/backend/src/main/kotlin/no/uib/echo/plugins/ContentNegotiation.kt
+++ b/backend/src/main/kotlin/no/uib/echo/plugins/ContentNegotiation.kt
@@ -11,6 +11,7 @@ fun Application.configureContentNegotiation() {
         json(
             Json {
                 ignoreUnknownKeys = true
+                encodeDefaults = true
             }
         )
     }

--- a/backend/src/main/kotlin/no/uib/echo/routes/UserRoutes.kt
+++ b/backend/src/main/kotlin/no/uib/echo/routes/UserRoutes.kt
@@ -23,7 +23,6 @@ import no.uib.echo.schema.masters
 import org.jetbrains.exposed.sql.StdOutSqlLogger
 import org.jetbrains.exposed.sql.addLogger
 import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.lowerCase
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update

--- a/backend/src/main/kotlin/no/uib/echo/routes/UserRoutes.kt
+++ b/backend/src/main/kotlin/no/uib/echo/routes/UserRoutes.kt
@@ -10,6 +10,7 @@ import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.routing
 import no.uib.echo.isEmailValid
@@ -31,6 +32,7 @@ fun Application.userRoutes() {
     routing {
         authenticate("auth-jwt") {
             getUser()
+            postUser()
             putUser()
         }
     }
@@ -71,12 +73,60 @@ fun Route.getUser() {
             HttpStatusCode.OK,
             UserJson(
                 user[User.email],
+                user[User.name],
                 user[User.alternateEmail],
                 user[User.degreeYear],
-                Degree.valueOf(user[User.degree]),
+                user[User.degree]?.let { Degree.valueOf(it) },
                 memberships.ifEmpty { emptyList() }
             )
         )
+    }
+}
+
+fun Route.postUser() {
+    post("/user") {
+        val email = call.principal<JWTPrincipal>()?.payload?.getClaim("email")?.asString()?.lowercase()
+
+        if (email == null) {
+            call.respond(HttpStatusCode.Unauthorized)
+            return@post
+        }
+
+        try {
+            val user = call.receive<UserJson>()
+
+            if (user.email != email) {
+                call.respond(HttpStatusCode.Forbidden)
+                return@post
+            }
+
+            val existingUser = transaction {
+                addLogger(StdOutSqlLogger)
+
+                User.select {
+                    User.email eq email
+                }.firstOrNull()
+            }
+
+            if (existingUser != null) {
+                call.respond(HttpStatusCode.Conflict, "User already exists.")
+                return@post
+            }
+
+            transaction {
+                addLogger(StdOutSqlLogger)
+
+                User.insert {
+                    it[User.email] = user.email.lowercase()
+                    it[name] = user.name
+                }
+            }
+
+            call.respond(HttpStatusCode.OK, "New user created with email = $${user.email.lowercase()} and name = ${user.name}.")
+        } catch (e: Exception) {
+            call.respond(HttpStatusCode.InternalServerError)
+            e.printStackTrace()
+        }
     }
 }
 
@@ -94,28 +144,36 @@ fun Route.putUser() {
 
         try {
             val user = call.receive<UserJson>()
+
+            if (user.email != email) {
+                call.respond(HttpStatusCode.Forbidden)
+                return@put
+            }
+
             val alternateEmail = user.alternateEmail?.lowercase()
 
-            if (alternateEmail != null) {
+            if (!alternateEmail.isNullOrBlank()) {
                 if (!isEmailValid(alternateEmail)) {
                     call.respond(HttpStatusCode.BadRequest, "Vennligst skriv inn en gyldig e-post.")
                     return@put
                 }
             }
 
-            if (user.degreeYear !in 1..5) {
+            if (user.degreeYear != null && user.degreeYear !in 1..5) {
                 call.respond(HttpStatusCode.BadRequest, "Vennligst velg et gyldig trinn.")
                 return@put
             }
 
             val degreeMismatch = "Studieretning og årstrinn stemmer ikke overens."
 
-            if ((user.degree in bachelors && user.degreeYear !in 1..3) ||
-                (user.degree in masters && user.degreeYear !in 4..5) ||
-                (user.degree == Degree.ARMNINF && user.degreeYear != 1)
-            ) {
-                call.respond(HttpStatusCode.BadRequest, degreeMismatch)
-                return@put
+            if (user.degree != null && user.degreeYear != null) {
+                if ((user.degree in bachelors && user.degreeYear !in 1..3) ||
+                    (user.degree in masters && user.degreeYear !in 4..5) ||
+                    (user.degree == Degree.ARMNINF && user.degreeYear != 1)
+                ) {
+                    call.respond(HttpStatusCode.BadRequest, degreeMismatch)
+                    return@put
+                }
             }
 
             val result = transaction {
@@ -130,6 +188,7 @@ fun Route.putUser() {
                     addLogger(StdOutSqlLogger)
                     User.insert {
                         it[User.email] = email
+                        it[name] = user.name
                         it[User.alternateEmail] = alternateEmail
                         it[degree] = user.degree.toString()
                         it[degreeYear] = user.degreeYear
@@ -144,6 +203,7 @@ fun Route.putUser() {
                 User.update({
                     User.email.lowerCase() eq email
                 }) {
+                    it[name] = user.name
                     it[User.alternateEmail] = alternateEmail
                     it[degree] = user.degree.toString()
                     it[degreeYear] = user.degreeYear
@@ -151,7 +211,7 @@ fun Route.putUser() {
             }
             call.respond(
                 HttpStatusCode.OK,
-                "User updated with email = $email, alternateEmail = $alternateEmail, degree = ${user.degree}, degreeYear = ${user.degreeYear}"
+                "User updated with email = $email, name = ${user.name}, alternateEmail = $alternateEmail, degree = ${user.degree}, degreeYear = ${user.degreeYear}"
             )
         } catch (e: Exception) {
             call.respond(HttpStatusCode.InternalServerError)

--- a/backend/src/main/kotlin/no/uib/echo/routes/UserRoutes.kt
+++ b/backend/src/main/kotlin/no/uib/echo/routes/UserRoutes.kt
@@ -95,7 +95,7 @@ fun Route.postUser() {
         try {
             val user = call.receive<UserJson>()
 
-            if (user.email != email) {
+            if (user.email.lowercase() != email) {
                 call.respond(HttpStatusCode.Forbidden)
                 return@post
             }
@@ -117,12 +117,12 @@ fun Route.postUser() {
                 addLogger(StdOutSqlLogger)
 
                 User.insert {
-                    it[User.email] = user.email.lowercase()
+                    it[User.email] = email
                     it[name] = user.name
                 }
             }
 
-            call.respond(HttpStatusCode.OK, "New user created with email = $${user.email.lowercase()} and name = ${user.name}.")
+            call.respond(HttpStatusCode.OK, "New user created with email = $email and name = ${user.name}.")
         } catch (e: Exception) {
             call.respond(HttpStatusCode.InternalServerError)
             e.printStackTrace()
@@ -145,7 +145,7 @@ fun Route.putUser() {
         try {
             val user = call.receive<UserJson>()
 
-            if (user.email != email) {
+            if (user.email.lowercase() != email) {
                 call.respond(HttpStatusCode.Forbidden)
                 return@put
             }
@@ -179,7 +179,7 @@ fun Route.putUser() {
             val result = transaction {
                 addLogger(StdOutSqlLogger)
                 User.select {
-                    User.email.lowerCase() eq email
+                    User.email eq email
                 }.firstOrNull()
             }
 
@@ -201,7 +201,7 @@ fun Route.putUser() {
             transaction {
                 addLogger(StdOutSqlLogger)
                 User.update({
-                    User.email.lowerCase() eq email
+                    User.email eq email
                 }) {
                     it[name] = user.name
                     it[User.alternateEmail] = alternateEmail

--- a/backend/src/main/kotlin/no/uib/echo/schema/User.kt
+++ b/backend/src/main/kotlin/no/uib/echo/schema/User.kt
@@ -7,17 +7,19 @@ import org.jetbrains.exposed.sql.Table
 @Serializable
 data class UserJson(
     val email: String,
+    val name: String,
     val alternateEmail: String? = null,
-    val degreeYear: Int,
-    val degree: Degree,
+    val degreeYear: Int? = null,
+    val degree: Degree? = null,
     val memberships: List<String> = emptyList()
 )
 
 object User : Table() {
     val email: Column<String> = text("email")
+    val name: Column<String> = text("name")
     val alternateEmail: Column<String?> = text("alternate_email").nullable()
-    val degreeYear: Column<Int> = integer("degree_year")
-    val degree: Column<String> = text("degree")
+    val degreeYear: Column<Int?> = integer("degree_year").nullable()
+    val degree: Column<String?> = text("degree").nullable()
 
     override val primaryKey: PrimaryKey = PrimaryKey(email)
 }

--- a/backend/src/main/resources/db/migration/V21__Unify_user.sql
+++ b/backend/src/main/resources/db/migration/V21__Unify_user.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "user"
+    ADD COLUMN name TEXT NOT NULL default "placeholder :)",
+    ALTER COLUMN degree DROP NOT NULL,
+    ALTER COLUMN degree_year DROP NOT NULL;

--- a/backend/src/main/resources/db/migration/V21__Unify_user.sql
+++ b/backend/src/main/resources/db/migration/V21__Unify_user.sql
@@ -1,4 +1,8 @@
 ALTER TABLE "user"
-    ADD COLUMN name TEXT NOT NULL default "placeholder :)",
-    ALTER COLUMN degree DROP NOT NULL,
+    ADD COLUMN name TEXT NOT NULL default 'placeholder :)';
+
+ALTER TABLE "user"
+    ALTER COLUMN degree DROP NOT NULL;
+
+ALTER TABLE "user"
     ALTER COLUMN degree_year DROP NOT NULL;

--- a/backend/src/test/kotlin/no/uib/echo/registration/DeleteRegistrationsTest.kt
+++ b/backend/src/test/kotlin/no/uib/echo/registration/DeleteRegistrationsTest.kt
@@ -4,7 +4,6 @@ import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.request.basicAuth
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.post
@@ -42,8 +41,6 @@ import java.net.URI
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import no.uib.echo.hap6
-import no.uib.echo.schema.HappeningInfoJson
 
 class DeleteRegistrationsTest {
     companion object {

--- a/backend/src/test/kotlin/no/uib/echo/registration/DeleteRegistrationsTest.kt
+++ b/backend/src/test/kotlin/no/uib/echo/registration/DeleteRegistrationsTest.kt
@@ -4,7 +4,9 @@ import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.basicAuth
 import io.ktor.client.request.delete
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -40,6 +42,8 @@ import java.net.URI
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import no.uib.echo.hap6
+import no.uib.echo.schema.HappeningInfoJson
 
 class DeleteRegistrationsTest {
     companion object {

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -24,3 +24,9 @@ NEXTAUTH_SECRET=secret_here
 #
 # Change backend URL (default is 'http://localhost:8080'):
 # NEXT_PUBLIC_BACKEND_URL=https://cool-backend.com:1234
+#
+# Disable sign in checks (default is false):
+# SIGN_IN_DISABLE_CHECK=true
+#
+# Only collect sign in metrics (default is false):
+# SIGN_IN_ONLY_COLLECT_DATA=true

--- a/frontend/cypress/support/component.tsx
+++ b/frontend/cypress/support/component.tsx
@@ -37,6 +37,8 @@ Cypress.Commands.add('mount', (component, options = {}) =>
             session={{
                 expires: new Date(Date.now() + 2 * 86400).toISOString(),
                 user: { name: 'admin' },
+                idToken: 'idToken',
+                accessToken: 'accessToken',
             }}
         >
             {component}

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -46,7 +46,7 @@ const NavLinks = (): JSX.Element => {
                 )}
                 {status === 'unauthenticated' && (
                     <NavLinkButton onClick={() => void onProfileClick()}>
-                        {isNorwegian ? 'Logg inn' : 'Log in'}
+                        {isNorwegian ? 'Logg inn' : 'Sign in'}
                     </NavLinkButton>
                 )}
             </Flex>

--- a/frontend/src/components/registration-form.tsx
+++ b/frontend/src/components/registration-form.tsx
@@ -25,7 +25,7 @@ import type { SubmitHandler } from 'react-hook-form';
 import { FormProvider, useForm } from 'react-hook-form';
 import type { Happening, HappeningType, Question } from '@api/happening';
 import type { RegFormValues } from '@api/registration';
-import type { UserWithName } from '@api/user';
+import type { User } from '@api/user';
 import { RegistrationAPI } from '@api/registration';
 import FormTerm from '@components/form-term';
 import FormQuestion from '@components/form-question';
@@ -86,7 +86,7 @@ interface Props {
     regVerifyToken: string | null;
     type: HappeningType;
     backendUrl: string;
-    user: UserWithName | null;
+    user: User | null;
 }
 
 const RegistrationForm = ({ happening, regVerifyToken, type, backendUrl, user }: Props): JSX.Element => {

--- a/frontend/src/lib/api/feide-group.ts
+++ b/frontend/src/lib/api/feide-group.ts
@@ -1,0 +1,81 @@
+import axios from 'axios';
+import type { decodeType } from 'typescript-json-decoder';
+import { literal, union, date, record, boolean, optional, string, array } from 'typescript-json-decoder';
+import type { ErrorMessage } from '@utils/error';
+
+const feideGroupDecoder = record({
+    id: string,
+    displayName: string,
+    basic: optional(union(literal('member'), literal('admin'), literal('owner'))),
+    description: optional(string),
+    type: optional(string),
+    parent: optional(string),
+    notBefore: optional(date),
+    notAfter: optional(date),
+    public: optional(boolean),
+    active: optional(boolean),
+    url: optional(string),
+    primaryOrgUnit: optional(boolean),
+    membership: record({
+        basic: optional(union(literal('member'), literal('admin'), literal('owner'))),
+        displayName: optional(string),
+        active: optional(boolean),
+        notBefore: optional(date),
+        fsroles: optional(array(string)),
+        subjectRelation: optional(string),
+        primaryOrgUnit: optional(boolean),
+        affiliation: optional(array(string)),
+        title: optional(array(string)),
+    }),
+});
+type FeideGroup = decodeType<typeof feideGroupDecoder>;
+
+const feideGroupEndpoint = 'https://groups-api.dataporten.no/groups';
+
+const FeideGroupAPI = {
+    isMemberOfGroup: async (accessToken: string, groupId: string): Promise<boolean> => {
+        try {
+            const { status, data } = await axios.get(`${feideGroupEndpoint}/me/groups/${groupId}`, {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                },
+                validateStatus: (statusCode: number) => statusCode < 500,
+            });
+
+            if (status === 200 && data?.basic === 'member' && data?.primaryOrgUnit === true) {
+                return true;
+            }
+
+            return false;
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.log(error);
+            return false;
+        }
+    },
+
+    getGroups: async (accessToken: string): Promise<Array<FeideGroup> | ErrorMessage> => {
+        try {
+            const { status, data } = await axios.get(`${feideGroupEndpoint}/me/groups`, {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                },
+                validateStatus: (statusCode: number) => statusCode < 500,
+            });
+
+            if (status === 200) {
+                return array(feideGroupDecoder)(data);
+            }
+
+            return {
+                message: `Error fetching groups, status: ${status}.`,
+            };
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.log(error);
+            return { message: JSON.stringify(error) };
+        }
+    },
+};
+
+export { FeideGroupAPI, type FeideGroup, feideGroupDecoder };

--- a/frontend/src/pages/500.tsx
+++ b/frontend/src/pages/500.tsx
@@ -1,0 +1,18 @@
+import { Box, Center, Heading, Text } from '@chakra-ui/react';
+import SEO from '@components/seo';
+
+const ErrorPage = (): JSX.Element => (
+    <>
+        <SEO title="Det har skjedd en feil" />
+        <Center>
+            <Box textAlign="center">
+                <Heading py="4rem" fontSize="9rem">
+                    500
+                </Heading>
+                <Text fontSize="2rem">Det har skjedd en feil.</Text>
+            </Box>
+        </Center>
+    </>
+);
+
+export default ErrorPage;

--- a/frontend/src/pages/api/auth/[...nextauth].ts
+++ b/frontend/src/pages/api/auth/[...nextauth].ts
@@ -1,5 +1,9 @@
 import NextAuth from 'next-auth';
 import type { NextAuthOptions } from 'next-auth';
+import { FeideGroupAPI } from '@api/feide-group';
+import { UserAPI } from '@api/user';
+import { isErrorMessage } from '@utils/error';
+import { FeedbackAPI } from '@api/feedback';
 
 export const authOptions: NextAuthOptions = {
     session: {
@@ -9,12 +13,89 @@ export const authOptions: NextAuthOptions = {
         maxAge: 3600,
     },
     callbacks: {
+        async signIn({ account, profile }) {
+            const signInDisabeCheck = process.env.SIGN_IN_DISABLE_CHECK === 'true';
+            if (signInDisabeCheck) {
+                // eslint-disable-next-line no-console
+                console.log('Sign in check disabled');
+                return true;
+            }
+
+            const signInOnlyCollectData = process.env.SIGN_IN_ONLY_COLLECT_DATA === 'true';
+
+            if (account?.access_token && account.id_token && profile?.email && profile.name) {
+                const isMember = await FeideGroupAPI.isMemberOfGroup(account.access_token, 'fc:org:uib.no:unit:12120');
+
+                if (!isMember) {
+                    if (signInOnlyCollectData) {
+                        const groups = await FeideGroupAPI.getGroups(account.access_token);
+                        // eslint-disable-next-line no-console
+                        console.log('User is not a member of the group, but only collecting data');
+                        void FeedbackAPI.sendFeedback({
+                            email: profile.email,
+                            name: profile.name,
+                            message: JSON.stringify(groups),
+                        });
+                        return true;
+                    }
+                    return '/nei';
+                }
+
+                const { email, name } = profile;
+
+                const response = await UserAPI.postInitialUser(account.id_token, email, name);
+
+                if (isErrorMessage(response)) {
+                    if (signInOnlyCollectData) {
+                        // eslint-disable-next-line no-console
+                        console.log('User could not be created, but only collecting data');
+                        void FeedbackAPI.sendFeedback({
+                            email,
+                            name,
+                            message: response.message,
+                        });
+                        return true;
+                    }
+                    return '/500';
+                }
+
+                if (response.status === 200 || response.status === 409) {
+                    return true;
+                }
+
+                if (signInOnlyCollectData) {
+                    // eslint-disable-next-line no-console
+                    console.log('User could not be created (status not 200 or 409), but only collecting data');
+                    void FeedbackAPI.sendFeedback({
+                        email,
+                        name,
+                        message: `Unknown error: ${JSON.stringify(response)}`,
+                    });
+                    return true;
+                }
+            }
+
+            return '/500';
+        },
         // eslint-disable-next-line @typescript-eslint/require-await
         async jwt({ token, account }) {
             if (account) {
                 token.idToken = account.id_token;
+                token.accessToken = account.access_token;
             }
+
             return token;
+        },
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async session({ session, token }) {
+            const { idToken, accessToken } = token;
+
+            if (typeof idToken === 'string' && typeof accessToken === 'string') {
+                session.idToken = idToken;
+                session.accessToken = accessToken;
+            }
+
+            return session;
         },
     },
     providers: [
@@ -26,7 +107,7 @@ export const authOptions: NextAuthOptions = {
             wellKnown: 'https://auth.dataporten.no/.well-known/openid-configuration',
             authorization: {
                 params: {
-                    scope: 'email userinfo-name profile userid openid',
+                    scope: 'email userinfo-name profile userid openid groups-edu groups-org groups-other',
                 },
             },
             clientId: process.env.FEIDE_CLIENT_ID,

--- a/frontend/src/pages/api/auth/[...nextauth].ts
+++ b/frontend/src/pages/api/auth/[...nextauth].ts
@@ -24,7 +24,7 @@ export const authOptions: NextAuthOptions = {
             const signInOnlyCollectData = process.env.SIGN_IN_ONLY_COLLECT_DATA === 'true';
 
             if (account?.access_token && account.id_token && profile?.email && profile.name) {
-                const isMember = await FeideGroupAPI.isMemberOfGroup(account.access_token, 'fc:org:uib.no:unit:12120');
+                const isMember = await FeideGroupAPI.isMemberOfGroup(account.access_token, 'fc:org:uib.no:unit:121200');
 
                 if (!isMember) {
                     if (signInOnlyCollectData) {

--- a/frontend/src/pages/api/user/index.ts
+++ b/frontend/src/pages/api/user/index.ts
@@ -57,7 +57,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
             const { email, name } = session;
 
             if (!email || !name) {
-                res.status(401).end('faka yu');
+                res.status(401).end();
                 return;
             }
 

--- a/frontend/src/pages/event/[slug].tsx
+++ b/frontend/src/pages/event/[slug].tsx
@@ -8,7 +8,7 @@ import { nb, enUS } from 'date-fns/locale';
 import Image from 'next/image';
 import NextLink from 'next/link';
 import type { ErrorMessage } from '@utils/error';
-import type { UserWithName } from '@api/user';
+import type { User } from '@api/user';
 import { UserAPI } from '@api/user';
 import RegistrationsList from '@components/registrations-list';
 import type { Happening, HappeningInfo } from '@api/happening';
@@ -43,7 +43,7 @@ const HappeningPage = ({ happening, backendUrl, happeningInfo, date, error }: Pr
         differenceInMilliseconds(regDate, date) > 172_800_000
             ? null
             : differenceInMilliseconds(regDate, date);
-    const [user, setUser] = useState<UserWithName | null>(null);
+    const [user, setUser] = useState<User | null>(null);
     const isNorwegian = useContext(LanguageContext);
     const [regsList, setRegsList] = useState<Array<Registration>>([]);
     const [regsListError, setRegsListError] = useState<ErrorMessage | null>(null);

--- a/frontend/src/pages/feide-group.tsx
+++ b/frontend/src/pages/feide-group.tsx
@@ -37,7 +37,7 @@ const FeideGroupPage = () => {
             {!isErrorMessage(group) && (
                 <>
                     <Heading>Feide Groups</Heading>
-                    <pre>{JSON.stringify(group, null, 2)}</pre>)
+                    <pre>{JSON.stringify(group, null, 2)}</pre>
                 </>
             )}
         </Section>

--- a/frontend/src/pages/feide-group.tsx
+++ b/frontend/src/pages/feide-group.tsx
@@ -1,0 +1,47 @@
+import { Spinner, Heading } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import Section from '@components/section';
+import { FeideGroupAPI, type FeideGroup } from '@api/feide-group';
+import { type ErrorMessage, isErrorMessage } from '@utils/error';
+
+const FeideGroupPage = () => {
+    const [group, setGroup] = useState<Array<FeideGroup> | ErrorMessage>([]);
+    const [loading, setLoading] = useState(true);
+    const { data } = useSession();
+
+    useEffect(() => {
+        const fetchGroups = async () => {
+            if (data) {
+                setLoading(true);
+                const response = await FeideGroupAPI.getGroups(data.accessToken);
+                setLoading(false);
+
+                setGroup(response);
+            }
+        };
+
+        void fetchGroups();
+    }, [data]);
+
+    return (
+        <Section>
+            {isErrorMessage(group) && <Heading>Failed to load</Heading>}
+            {loading && (
+                <>
+                    <Heading>Loading...</Heading>
+                    <Spinner />
+                </>
+            )}
+
+            {!isErrorMessage(group) && (
+                <>
+                    <Heading>Feide Groups</Heading>
+                    <pre>{JSON.stringify(group, null, 2)}</pre>)
+                </>
+            )}
+        </Section>
+    );
+};
+
+export default FeideGroupPage;

--- a/frontend/src/pages/nei.tsx
+++ b/frontend/src/pages/nei.tsx
@@ -1,0 +1,16 @@
+import { Box, Center, Heading, Text } from '@chakra-ui/react';
+
+const NeiPage = (): JSX.Element => (
+    <Center>
+        <Box textAlign="center">
+            <Heading py="3rem" fontSize="8rem">
+                Nei
+            </Heading>
+            <Text px="25%" fontSize="2rem">
+                Du er ikke medlem av institutt for informatikk. Om du mener dette ikke stemmer, ta kontakt med Webkom.
+            </Text>
+        </Box>
+    </Center>
+);
+
+export default NeiPage;

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useContext } from 'react';
 import { signIn, signOut, useSession } from 'next-auth/react';
 import { Spinner, Center, Text, Button, useColorModeValue, Link, Flex, Spacer, Heading } from '@chakra-ui/react';
 import { IoMdHome } from 'react-icons/io';
-import type { UserWithName } from '@api/user';
+import type { User } from '@api/user';
 import { UserAPI } from '@api/user';
 import { type ErrorMessage, isErrorMessage } from '@utils/error';
 import Section from '@components/section';
@@ -11,7 +11,7 @@ import SEO from '@components/seo';
 import LanguageContext from 'language-context';
 
 const ProfilePage = (): JSX.Element => {
-    const [user, setUser] = useState<UserWithName | null>();
+    const [user, setUser] = useState<User | null>();
     const [error, setError] = useState<ErrorMessage>();
     const [loading, setLoading] = useState<boolean>(true);
 
@@ -55,9 +55,11 @@ const ProfilePage = (): JSX.Element => {
                                     <Text textAlign="center">
                                         {isNorwegian
                                             ? 'Prøv å logg ut og så inn igjen, eller ta kontakt med Webkom.'
-                                            : 'Try logging out and then logging in again, or contact Webkom.'}
+                                            : 'Try signing out and then signing in again, or contact Webkom.'}
                                     </Text>
-                                    <Button onClick={() => void signOut()}>Logg ut</Button>
+                                    <Button onClick={() => void signOut()}>
+                                        {isNorwegian ? 'Logg ut' : 'Sign out'}
+                                    </Button>
                                 </Flex>
                             )}
                             {loading && (
@@ -67,7 +69,7 @@ const ProfilePage = (): JSX.Element => {
                                     </Heading>
                                     <Spinner size="xl" mx="auto" />
                                     <Button onClick={() => void signOut()}>
-                                        {isNorwegian ? 'Logg ut' : 'Log out'}
+                                        {isNorwegian ? 'Logg ut' : 'Sign out'}
                                     </Button>
                                 </Flex>
                             )}
@@ -100,7 +102,7 @@ const ProfilePage = (): JSX.Element => {
                                 borderRadius="0.5rem"
                                 onClick={() => void signIn('feide')}
                             >
-                                {isNorwegian ? 'Logg inn med feide' : 'Log in with feide'}
+                                {isNorwegian ? 'Logg inn med Feide' : 'Sign in with Feide'}
                             </Button>
                             <Spacer />
                             <Link href="/" alignItems="center" justifyContent="center" display="flex">

--- a/frontend/src/types/next-auth.d.ts
+++ b/frontend/src/types/next-auth.d.ts
@@ -1,0 +1,13 @@
+import type { DefaultSession } from 'next-auth';
+
+declare module 'next-auth' {
+    interface JWT {
+        idToken: string;
+        accessToken: string;
+    }
+
+    interface Session extends DefaultSession {
+        idToken: string;
+        accessToken: string;
+    }
+}


### PR DESCRIPTION
- Gjort slik at `User`-typen frontend er helt lik som `user`-tabellen i backend. Det innebærer at vi nå lagrer navn i databasen, og at vi ikke lenger har to typer i frontend (`UserWithName` er borte, nå har vi bare `User`).

- Koblet opp frontend mot Feide sin gruppe-API. Der kan man hente ut hvilke grupper en student er medlem i (altså fag, institutt, fakultet osv...). Laget en sjekk i `signIn()` som kjører hver gang man logger inn. Der sjekker vi om brukeren er medlem av institutt for informatikk, og prøver å oprette en ny bruker i backend med en gang. Jeg la til miljøvariabler for å aktivere/deaktivere deler av den funksjonaliteten; man kan enten skru den helt av, eller kjøre alle sjekker men bare logge om det går galt. Jeg brukte `FeedbackAPI` for dette siden det var lettest, det går vel fint? Blir ikke brukt til så mye annet. Det jeg tenkte var å bare kjøre logging i noen uker for å se om det funker for de det skal funke for, og så aktivere det for alle etterhvert.

- Laget API-typer for Feide-grupper. Om man er logget inn kan man se de på `/feide-group`; tenker vi bare kan ha den liggende for testing inntil videre?

- Endret det slikt at `Session` man får fra `useSession()` nå inneholder både `idToken` (brukes til identifisere med backend) og (denne er ny) `accessToken` (brukes for Feide sin gruppe-API). Jeg tror dette ikke skal være noe mer farlig sikkerhetsmessig enn å bare ha de på server-side, siden `idToken` og `accessToken` ikke trengs å holde hemmelige fra brukeren. Vi kan da evt. senere slutte å bruke Next sin API som mellomledd for `User` og `Feedback`. Om vi finner ut at det ikke er sikkert kan vi også endre det.

- Endret på litt div. tekst knyttet til profil og innlogging, og la til en toast for feilmeldinger på `/profile`.