### PR TITLE
🐛 Remove `.` and `renovate/` from branch name to Azure

### DIFF
--- a/.github/workflows/docker_tests_and_previews.yaml
+++ b/.github/workflows/docker_tests_and_previews.yaml
@@ -291,7 +291,7 @@ jobs:
         id: env_vars
         if: steps.changed-files-backend.outputs.any_changed == 'true' || steps.changed-files-tf.outputs.any_changed == 'true'
         run: |
-          echo "BRANCH_NAME_FORMATTED=$(echo "$BRANCH_NAME" | sed -e 's/[\/_]/-/g')" >> $GITHUB_OUTPUT
+          echo "BRANCH_NAME_FORMATTED=$(echo "$BRANCH_NAME" | sed -e 's/renovate\///g' -e 's/[\/_\.]/-/g')" >> $GITHUB_OUTPUT
           echo "BACKEND_TAG=$BACKEND_TAG" >> $GITHUB_OUTPUT
         env:
           BACKEND_TAG: ${{ steps.changed-files-backend.outputs.any_changed == 'true' && github.sha || 'latest' }}
@@ -310,7 +310,7 @@ jobs:
           TF_VAR_resource_group_name: 'echo-web-${{ steps.env_vars.outputs.BRANCH_NAME_FORMATTED }}'
           TF_VAR_location: norwayeast
           TF_VAR_db_password: ${{ secrets.DB_PASSWORD_DEV }}
-          TF_VAR_backend_image: '${{ env.IMAGE_NAME}}/backend:${{ steps.env_vars.outputs.BACKEND_TAG }}'
+          TF_VAR_backend_image: '${{ env.IMAGE_NAME }}/backend:${{ steps.env_vars.outputs.BACKEND_TAG }}'
           ARM_CLIENT_ID: c320aed0-41eb-4089-aedb-8a4ece92c3b5
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: 8afc7368-510a-404a-b4dd-c7351977b037


### PR DESCRIPTION
Det ødelegger for URL til backend når vi gir ressurser i Azure navn som inneholder punktum. Fjerner også 'renovate/'-prefiksen fra navnet, siden det kan hende at ressurser får samme navn pga. 'renovate/' er på alle pull requester fra Renovate-bot.