### PR TITLE
🐛 Filter non Feide users on dashboard

### DIFF
--- a/backend/src/main/kotlin/no/uib/echo/routes/UserRoutes.kt
+++ b/backend/src/main/kotlin/no/uib/echo/routes/UserRoutes.kt
@@ -26,8 +26,8 @@ import no.uib.echo.schema.nullableStringToDegree
 import org.jetbrains.exposed.sql.StdOutSqlLogger
 import org.jetbrains.exposed.sql.addLogger
 import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.select
-import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
 
@@ -271,7 +271,9 @@ fun Route.getAllUsers() {
 
         val users = transaction {
             addLogger(StdOutSqlLogger)
-            User.selectAll().map { it ->
+            User.select {
+                User.email like "%@student.uib.no" or (User.email like "%@uib.no")
+            }.map { it ->
                 UserJson(
                     it[User.email],
                     it[User.name],

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -19,7 +19,7 @@ const ProfilePage = (): JSX.Element => {
 
     return (
         <>
-            <SEO title={status === 'unauthenticated' ? 'Min profil' : 'Logg inn'} />
+            <SEO title={status === 'authenticated' ? 'Min profil' : 'Logg inn'} />
             {status === 'authenticated' && <ProfileInfo />}
             {status === 'loading' && (
                 <Center>


### PR DESCRIPTION
Tar bort alle brukere som ble opprettet for å koble sammen brukere og påmeldinger. Kutter drastisk ned på antall brukere som dukker opp på dashbordet. Fikset også tittel på profilsiden.