### PR TITLE
🐛 Fix registration count on /event/[slug]

### DIFF
--- a/backend/src/main/kotlin/no/uib/echo/schema/Registration.kt
+++ b/backend/src/main/kotlin/no/uib/echo/schema/Registration.kt
@@ -47,13 +47,9 @@ fun countRegistrationsDegreeYear(slug: String, range: IntRange, waitList: Boolea
     return transaction {
         addLogger(StdOutSqlLogger)
 
-        val usersInRange = User.select {
-            User.degreeYear inList range
-        }.toList().map { it[User.email] }
-
         Registration.select {
             Registration.happeningSlug eq slug and
-                (Registration.userEmail inList usersInRange) and
+                (Registration.degreeYear inList range) and
                 (Registration.waitList eq waitList)
         }.count()
     }.toInt()


### PR DESCRIPTION
Feilen var at vi sjekket hvilke brukere som hadde årstrinn innenfor området, istedenfor å sjekke hvilke påmeldinger som hadde årstrinn innenfor området. Siden mange av påmeldingene ble laget før vi gjorde det obligatorisk å ha en bruker med informasjon utfylt, hadde de ikke et årstrinn tilknyttet seg, og de dukket ikke opp.