### PR TITLE
🐛 Fix wrong key info & broken regs list filter

### DIFF
--- a/frontend/src/components/happening-key-info.tsx
+++ b/frontend/src/components/happening-key-info.tsx
@@ -15,10 +15,8 @@ interface Props {
 const HappeningKeyInfo = ({ event, registrationCounts = [] }: Props): JSX.Element => {
     const isNorwegian = useContext(LanguageContext);
 
-    const totalReg = registrationCounts.find((regCount: RegistrationCount) => regCount.slug === event.slug)?.count ?? 0;
-    const waitListCount =
-        registrationCounts.find((regCount: RegistrationCount) => regCount.slug === event.slug)?.waitListCount ?? 0;
-    const totalRegWithoutWaitList = totalReg - waitListCount;
+    const totalRegs =
+        registrationCounts.find((regCount: RegistrationCount) => regCount.slug === event.slug)?.count ?? 0;
     const totalSpots = event.spotRanges.map((spotRange: SpotRange) => spotRange.spots).reduce((a, b) => a + b, 0);
 
     return (
@@ -43,13 +41,11 @@ const HappeningKeyInfo = ({ event, registrationCounts = [] }: Props): JSX.Elemen
                 <Flex alignItems="center" justifyContent="flex-end">
                     {isPast(new Date(event.registrationDate)) ? (
                         <Text ml="1" fontSize="1rem">
-                            {totalRegWithoutWaitList >= totalSpots && totalSpots !== 0
+                            {totalRegs >= totalSpots && totalSpots !== 0
                                 ? isNorwegian
                                     ? `Fullt`
                                     : `Full`
-                                : `${totalRegWithoutWaitList} ${isNorwegian ? 'av' : 'of'} ${
-                                      totalSpots === 0 ? '∞' : totalSpots
-                                  }`}
+                                : `${totalRegs} ${isNorwegian ? 'av' : 'of'} ${totalSpots === 0 ? '∞' : totalSpots}`}
                         </Text>
                     ) : (
                         <Text ml="1" fontSize="1rem">

--- a/frontend/src/components/registration-row.tsx
+++ b/frontend/src/components/registration-row.tsx
@@ -114,7 +114,7 @@ const RegistrationRow = ({ registration, questions, studentGroups }: Props) => {
                 <Td
                     fontSize="md"
                     fontWeight={userIsEligibleForEarlyReg ? 'bold' : 'normal'}
-                    color={userIsEligibleForEarlyReg ? 'green.400' : 'white'}
+                    color={userIsEligibleForEarlyReg ? 'green.400' : 'inherit'}
                     fontStyle={userIsEligibleForEarlyReg ? 'italic' : 'normal'}
                 >
                     {registration.memberships.map(capitalize).join(', ')}

--- a/frontend/src/components/registrations-list.tsx
+++ b/frontend/src/components/registrations-list.tsx
@@ -69,7 +69,10 @@ const RegistrationsList = ({ registrations, title, error, studentGroups }: Props
                     reg.name.toLowerCase().includes(search.toLowerCase()) ||
                     (reg.alternateEmail ?? reg.email).toLowerCase().includes(search.toLowerCase()),
             )
-            ?.filter((reg) => hasOverlap(reg.memberships, studentGroups) && !hideStudentGroups) ?? [];
+            ?.filter(
+                (reg) =>
+                    !(notEmptyOrNull(studentGroups) && hasOverlap(reg.memberships, studentGroups) && hideStudentGroups),
+            ) ?? [];
 
     const questions =
         registrations
@@ -265,9 +268,10 @@ const RegistrationsList = ({ registrations, title, error, studentGroups }: Props
                                                 setYear(0);
                                                 setWaitlist(-1);
                                                 setSearch('');
+                                                setHideStudentGroups(false);
                                             }}
                                         >
-                                            Reset filter
+                                            Nullstill filter
                                         </Button>
                                     </Flex>
                                 </Center>


### PR DESCRIPTION
F.eks. står det 18/40 på bedriftsturen på forsiden, pga. gamle endepunktet `/registration/count` hentet ut en `regCount` som inneholdt både venteliste og ikke-venteliste, mens nye henter ut bare på ikke-venteliste for verdien til `regCount`.

Fikset også filter for påmeldinger, ingen påmeldinger dukket opp på tidligere arrangementer.

**EDIT:** og fikset farge på tekst på påmeldingslistene