### PR TITLE
💄 Fix scaling of member profile images

### DIFF
--- a/frontend/src/components/member-profile.tsx
+++ b/frontend/src/components/member-profile.tsx
@@ -1,11 +1,7 @@
-import { Avatar, Box, Center, chakra, Text, useBreakpointValue } from '@chakra-ui/react';
+import { Avatar, Flex, Box, Center, Text, useBreakpointValue } from '@chakra-ui/react';
 import Image from 'next/image';
 import type { Profile } from '@api/profile';
-
-const MemberImage = chakra(Image, {
-    baseStyle: { maxH: 128, maxW: 128 },
-    shouldForwardProp: (prop) => ['width', 'height', 'src', 'alt', 'quality'].includes(prop),
-});
+import { imgUrlFor } from '@api/sanity';
 
 const getInitials = (name: string) => {
     const words = name.split(' ');
@@ -18,22 +14,20 @@ interface Props {
 }
 
 const MemberProfile = ({ profile, role }: Props): JSX.Element => {
-    const memberImageSize = useBreakpointValue([96, 96, 128]);
+    const imgSize = useBreakpointValue([96, 96, 128]);
 
     return (
         <Box p={['0', null, '.5em']} w={['120px', null, '200px']} overflow="visible" textAlign="center">
             <Center>
                 {profile.imageUrl && (
-                    <MemberImage
-                        width={128}
-                        height={128}
-                        src={profile.imageUrl}
-                        alt={profile.name}
-                        quality={100}
-                        w={memberImageSize}
-                        h={memberImageSize}
-                        borderRadius="100%"
-                    />
+                    <Flex borderRadius="100%" overflow="hidden">
+                        <Image
+                            src={imgUrlFor(profile.imageUrl).width(512).height(512).fit('crop').auto('format').url()}
+                            alt={profile.name}
+                            width={imgSize ?? 128}
+                            height={imgSize ?? 128}
+                        />
+                    </Flex>
                 )}
                 {!profile.imageUrl && (
                     <Avatar getInitials={getInitials} size="2xl" name={profile.name} src={undefined} />


### PR DESCRIPTION
Fikser sykt mye scaling-problemer på undergruppesidene. Bruker noen funksjoner fra Sanity som bare mekker alt jævlig nice.

<details>
<summary>Før</summary>
<br>
<img src="https://user-images.githubusercontent.com/6720179/204535154-f2ab8549-6b2b-4570-95d3-147e92fd4e95.png" alt="før" />
</details>
<details>
<summary>Etter</summary>
<br>
<img src="https://user-images.githubusercontent.com/6720179/204535211-d5258920-d2f9-4a19-a8d6-cb6168500536.png" alt="etter" />
</details>