### PR TITLE
:recycle:  Add useAuth hook for global User state

### DIFF
--- a/.github/workflows/docker_tests_and_previews.yaml
+++ b/.github/workflows/docker_tests_and_previews.yaml
@@ -144,8 +144,8 @@ jobs:
         with:
           working-directory: frontend
           install-command: yarn --frozen-lockfile
-          build: yarn build
-          start: yarn start
+          build: env NODE_ENV=development yarn build --no-lint
+          start: env NODE_ENV=development yarn start
           wait-on: 'http://localhost:3000, http://localhost:8080/status'
           config: video=false
           browser: firefox

--- a/.github/workflows/docker_tests_and_previews.yaml
+++ b/.github/workflows/docker_tests_and_previews.yaml
@@ -144,13 +144,15 @@ jobs:
         with:
           working-directory: frontend
           install-command: yarn --frozen-lockfile
-          start: yarn dev
+          build: yarn build
+          start: yarn start
           wait-on: 'http://localhost:3000, http://localhost:8080/status'
           config: video=false
           browser: firefox
         env:
           SANITY_DATASET: testing
           NEXTAUTH_SECRET: very-secret-string-123
+          NEXTAUTH_URL: http://localhost:3000
           FEIDE_CLIENT_ID: ${{ secrets.FEIDE_CLIENT_ID }}
           FEIDE_CLIENT_SECRET: ${{ secrets.FEIDE_CLIENT_SECRET }}
           SIGN_IN_DISABLE_CHECK: true

--- a/.github/workflows/docker_tests_and_previews.yaml
+++ b/.github/workflows/docker_tests_and_previews.yaml
@@ -144,8 +144,7 @@ jobs:
         with:
           working-directory: frontend
           install-command: yarn --frozen-lockfile
-          build: env NODE_ENV=development yarn build --no-lint
-          start: env NODE_ENV=development yarn start
+          start: yarn dev
           wait-on: 'http://localhost:3000, http://localhost:8080/status'
           config: video=false
           browser: firefox

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     },
 
     retries: {
-        runMode: 3,
+        runMode: 5,
     },
 
     component: {

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -1,4 +1,7 @@
 import { Box, Flex, Spacer } from '@chakra-ui/react';
+import { getMonth } from 'date-fns';
+import Snowfall from 'react-snowfall';
+import { useState, useEffect } from 'react';
 import Footer from '@components/footer';
 import Header from '@components/header';
 import AnimatedIcons from '@components/animated-icons';
@@ -9,8 +12,16 @@ interface Props {
 }
 
 const Layout = ({ children }: Props): JSX.Element => {
+    // https://nextjs.org/docs/messages/react-hydration-error
+    const [SSR, setSSR] = useState(true);
+
+    useEffect(() => {
+        setSSR(false);
+    }, []);
+
     return (
         <AnimatedIcons n={50}>
+            {!SSR && getMonth(new Date()) === 11 && <Snowfall snowflakeCount={200} color="#ffffff" />}
             <Flex direction="column" minH="100vh" data-testid="layout">
                 <Header />
                 <Box maxW="1500" w={['97%', null, null, '90%']} m="auto">

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -16,11 +16,11 @@ import type { RefObject } from 'react';
 import NavLink, { NavLinkButton } from '@components/nav-link';
 import ColorModeButton from '@components/color-mode-button';
 import useLanguage from '@hooks/use-language';
-import useUser from '@hooks/use-user';
+import useAuth from '@hooks/use-auth';
 
 const NavLinks = (): JSX.Element => {
     const isNorwegian = useLanguage();
-    const { signedIn, loading } = useUser();
+    const { signedIn, loading } = useAuth();
     const router = useRouter();
     const onProfileClick = () => {
         if (signedIn) {

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -8,20 +8,22 @@ import {
     DrawerOverlay,
     Flex,
     Heading,
+    Skeleton,
 } from '@chakra-ui/react';
-import { signIn, useSession } from 'next-auth/react';
+import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import type { RefObject } from 'react';
 import NavLink, { NavLinkButton } from '@components/nav-link';
 import ColorModeButton from '@components/color-mode-button';
 import useLanguage from '@hooks/use-language';
+import useUser from '@hooks/use-user';
 
 const NavLinks = (): JSX.Element => {
     const isNorwegian = useLanguage();
-    const { status } = useSession();
+    const { signedIn, loading } = useUser();
     const router = useRouter();
     const onProfileClick = () => {
-        if (status === 'authenticated') {
+        if (signedIn) {
             void router.push('/profile');
         } else {
             void signIn('feide');
@@ -40,14 +42,14 @@ const NavLinks = (): JSX.Element => {
             {/* <NavLink text="Jobb" href="/job" data-cy="jobb" /> */}
             <NavLink text={isNorwegian ? 'Om echo' : 'About echo'} href="/om-echo/om-oss" data-cy="om-oss" />
             <Flex data-cy="min-profil">
-                {status === 'authenticated' && (
-                    <NavLink text={isNorwegian ? 'Min profil' : 'My profile'} href="/profile" />
-                )}
-                {status === 'unauthenticated' && (
-                    <NavLinkButton onClick={() => void onProfileClick()}>
-                        {isNorwegian ? 'Logg inn' : 'Sign in'}
-                    </NavLinkButton>
-                )}
+                <Skeleton isLoaded={!loading}>
+                    {signedIn && <NavLink text={isNorwegian ? 'Min profil' : 'My profile'} href="/profile" />}
+                    {!signedIn && (
+                        <NavLinkButton onClick={() => void onProfileClick()}>
+                            {isNorwegian ? 'Logg inn' : 'Sign in'}
+                        </NavLinkButton>
+                    )}
+                </Skeleton>
             </Flex>
             <ColorModeButton />
         </Flex>

--- a/frontend/src/components/profile-info.tsx
+++ b/frontend/src/components/profile-info.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { signOut, useSession } from 'next-auth/react';
+import { signOut } from 'next-auth/react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm, FormProvider } from 'react-hook-form';
 import { MdOutlineEmail } from 'react-icons/md';
@@ -42,7 +42,7 @@ import useLanguage from '@hooks/use-language';
 import useUser from '@hooks/use-user';
 
 const ProfileInfo = () => {
-    const { user, loading: userLoading, error, setUser } = useUser();
+    const { user, loading: userLoading, error, signedIn, setUser, idToken } = useUser();
     const [loading, setLoading] = useState<boolean>(userLoading);
 
     const [saved, setSaved] = useState<boolean>(false);
@@ -60,8 +60,6 @@ const ProfileInfo = () => {
     const toast = useToast();
     const iconColor = useColorModeValue('black', 'white');
 
-    const { data, status } = useSession();
-
     useEffect(() => {
         if (user) {
             setValue('degree', user.degree);
@@ -74,7 +72,7 @@ const ProfileInfo = () => {
     }, [user, setValue]);
 
     const submitForm: SubmitHandler<ProfileFormValues> = async (profileFormVals: ProfileFormValues) => {
-        if (!user || status !== 'authenticated') {
+        if (!user || !signedIn) {
             toast({
                 title: isNorwegian ? 'Du er ikke logget inn' : 'You are not signed in',
                 description: isNorwegian ? 'Vennligst prøv på nytt' : 'Please try again',
@@ -96,7 +94,8 @@ const ProfileInfo = () => {
             memberships: [],
         };
 
-        const res = await UserAPI.putUser(newUser, data.idToken);
+        // !user || !signed in implies idToken is not null, fuck off typescript.
+        const res = await UserAPI.putUser(newUser, idToken!);
 
         if (isErrorMessage(res)) {
             toast({

--- a/frontend/src/components/profile-info.tsx
+++ b/frontend/src/components/profile-info.tsx
@@ -33,18 +33,17 @@ import capitalize from '@utils/capitalize';
 import type { ProfileFormValues, User } from '@api/user';
 import { UserAPI, userIsComplete } from '@api/user';
 import { isErrorMessage } from '@utils/error';
-import type { ErrorMessage } from '@utils/error';
 import FormDegree from '@components/form-degree';
 import Unauthorized from '@components/unauthorized';
 import FormDegreeYear from '@components/form-degree-year';
 import IconText from '@components/icon-text';
 import Section from '@components/section';
 import useLanguage from '@hooks/use-language';
+import useUser from '@hooks/use-user';
 
-const ProfileInfo = (): JSX.Element => {
-    const [user, setUser] = useState<User | null>();
-    const [error, setError] = useState<ErrorMessage>();
-    const [loading, setLoading] = useState<boolean>(true);
+const ProfileInfo = () => {
+    const { user, loading: userLoading, error, setUser } = useUser();
+    const [loading, setLoading] = useState<boolean>(userLoading);
 
     const [saved, setSaved] = useState<boolean>(false);
     const [satisfied, setSatisfied] = useState<boolean>(false);
@@ -62,22 +61,6 @@ const ProfileInfo = (): JSX.Element => {
     const iconColor = useColorModeValue('black', 'white');
 
     const { data, status } = useSession();
-
-    useEffect(() => {
-        const fetchUser = async () => {
-            if (!data?.idToken || !data.user?.email || !data.user.name) return;
-
-            const result = await UserAPI.getUser(data.user.email, data.user.name, data.idToken);
-
-            if (isErrorMessage(result)) {
-                setError(result);
-            } else {
-                setUser(result);
-            }
-        };
-
-        void fetchUser();
-    }, [data]);
 
     useEffect(() => {
         if (user) {

--- a/frontend/src/components/reaction-buttons.tsx
+++ b/frontend/src/components/reaction-buttons.tsx
@@ -1,10 +1,10 @@
 import type { ButtonProps } from '@chakra-ui/react';
 import { useToast, ButtonGroup, Button, Text } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
-import { useSession } from 'next-auth/react';
 import type { Reaction, ReactionType } from '@api/reaction';
 import ReactionAPI from '@api/reaction';
 import { isErrorMessage } from '@utils/error';
+import useUser from '@hooks/use-user';
 
 const reactions = {
     like: {
@@ -35,13 +35,13 @@ interface Props {
 
 const ReactionButtons = ({ slug }: Props) => {
     const toast = useToast();
-    const session = useSession();
+    const { idToken } = useUser();
 
     const [data, setData] = useState<Reaction | null>(null);
 
     useEffect(() => {
         const fetchReactions = async () => {
-            const result = await ReactionAPI.get(slug, session.data?.idToken);
+            const result = await ReactionAPI.get(slug, idToken);
 
             if (isErrorMessage(result)) {
                 return;
@@ -51,10 +51,10 @@ const ReactionButtons = ({ slug }: Props) => {
         };
 
         void fetchReactions();
-    }, [session.data?.idToken, slug, toast]);
+    }, [idToken, slug, toast]);
 
     const handleClick = async (reaction: ReactionType) => {
-        const result = await ReactionAPI.post(slug, reaction, session.data?.idToken);
+        const result = await ReactionAPI.put(slug, reaction, idToken);
 
         if (isErrorMessage(result)) {
             toast({

--- a/frontend/src/components/registration-form.tsx
+++ b/frontend/src/components/registration-form.tsx
@@ -18,7 +18,6 @@ import {
     AlertIcon,
     Center,
 } from '@chakra-ui/react';
-import { useSession } from 'next-auth/react';
 import type { SubmitHandler } from 'react-hook-form';
 import { FormProvider, useForm } from 'react-hook-form';
 import { MdOutlineArrowForward } from 'react-icons/md';
@@ -65,7 +64,7 @@ const RegistrationForm = ({ happening, type }: Props): JSX.Element => {
     const isNorwegian = useLanguage();
     const methods = useForm<RegFormValues>();
     const { register, handleSubmit } = methods;
-    const { user, loading, signedIn } = useUser();
+    const { user, loading, signedIn, idToken } = useUser();
 
     const userIsEligibleForEarlyReg = hasOverlap(happening.studentGroups, user?.memberships);
     const regDate = chooseDate(
@@ -75,8 +74,6 @@ const RegistrationForm = ({ happening, type }: Props): JSX.Element => {
     );
 
     const toast = useToast();
-
-    const { data: session } = useSession();
 
     const submitForm: SubmitHandler<RegFormValues> = async (data) => {
         if (!signedIn) {
@@ -97,8 +94,8 @@ const RegistrationForm = ({ happening, type }: Props): JSX.Element => {
                 }),
                 type: type,
             },
-            // signedIn === true implies idToken is not null
-            session!.idToken,
+            // signedIn === true implies idToken is not null. Fuck off typescript, jeg banker deg opp.
+            idToken!,
         );
 
         if (statusCode === 200 || statusCode === 202) {

--- a/frontend/src/components/registration-form.tsx
+++ b/frontend/src/components/registration-form.tsx
@@ -33,7 +33,7 @@ import FormQuestion from '@components/form-question';
 import useLanguage from '@hooks/use-language';
 import hasOverlap from '@utils/has-overlap';
 import capitalize from '@utils/capitalize';
-import useUser from '@hooks/use-user';
+import useAuth from '@hooks/use-auth';
 
 const codeToStatus = (statusCode: number): 'success' | 'warning' | 'error' => {
     if (statusCode === 200) return 'success';
@@ -64,7 +64,7 @@ const RegistrationForm = ({ happening, type }: Props): JSX.Element => {
     const isNorwegian = useLanguage();
     const methods = useForm<RegFormValues>();
     const { register, handleSubmit } = methods;
-    const { user, loading, signedIn, idToken } = useUser();
+    const { user, loading, signedIn, idToken } = useAuth();
 
     const userIsEligibleForEarlyReg = hasOverlap(happening.studentGroups, user?.memberships);
     const regDate = chooseDate(
@@ -76,7 +76,7 @@ const RegistrationForm = ({ happening, type }: Props): JSX.Element => {
     const toast = useToast();
 
     const submitForm: SubmitHandler<RegFormValues> = async (data) => {
-        if (!signedIn) {
+        if (!signedIn || !idToken) {
             toast({
                 title: isNorwegian ? 'Du er ikke logget inn.' : 'You are not signed in.',
                 description: isNorwegian ? 'Logg inn for å melde deg på.' : 'Sign in to register.',
@@ -95,7 +95,7 @@ const RegistrationForm = ({ happening, type }: Props): JSX.Element => {
                 type: type,
             },
             // signedIn === true implies idToken is not null. Fuck off typescript, jeg banker deg opp.
-            idToken!,
+            idToken,
         );
 
         if (statusCode === 200 || statusCode === 202) {

--- a/frontend/src/components/registration-row.tsx
+++ b/frontend/src/components/registration-row.tsx
@@ -19,12 +19,12 @@ import {
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { motion } from 'framer-motion';
-import { useSession } from 'next-auth/react';
 import type { Registration } from '@api/registration';
 import { RegistrationAPI } from '@api/registration';
 import notEmptyOrNull from '@utils/not-empty-or-null';
 import capitalize from '@utils/capitalize';
 import hasOverlap from '@utils/has-overlap';
+import useUser from '@hooks/use-user';
 
 interface Props {
     registration: Registration;
@@ -43,12 +43,12 @@ const RegistrationRow = ({ registration, questions, studentGroups }: Props) => {
 
     const router = useRouter();
 
-    const { data } = useSession();
+    const { idToken, signedIn } = useUser();
 
     const userIsEligibleForEarlyReg = hasOverlap(studentGroups, registration.memberships);
 
     const handleDelete = async () => {
-        if (!data?.idToken) {
+        if (!signedIn) {
             toast({
                 title: 'Du er ikke logget inn',
                 status: 'error',
@@ -57,7 +57,8 @@ const RegistrationRow = ({ registration, questions, studentGroups }: Props) => {
             return;
         }
 
-        const { error } = await RegistrationAPI.deleteRegistration(registration.slug, registration.email, data.idToken);
+        // !signedIn implies idToken is not null
+        const { error } = await RegistrationAPI.deleteRegistration(registration.slug, registration.email, idToken!);
 
         onClose();
 

--- a/frontend/src/components/registration-row.tsx
+++ b/frontend/src/components/registration-row.tsx
@@ -24,7 +24,7 @@ import { RegistrationAPI } from '@api/registration';
 import notEmptyOrNull from '@utils/not-empty-or-null';
 import capitalize from '@utils/capitalize';
 import hasOverlap from '@utils/has-overlap';
-import useUser from '@hooks/use-user';
+import useAuth from '@hooks/use-auth';
 
 interface Props {
     registration: Registration;
@@ -43,22 +43,21 @@ const RegistrationRow = ({ registration, questions, studentGroups }: Props) => {
 
     const router = useRouter();
 
-    const { idToken, signedIn } = useUser();
+    const { idToken, signedIn } = useAuth();
 
     const userIsEligibleForEarlyReg = hasOverlap(studentGroups, registration.memberships);
 
     const handleDelete = async () => {
-        if (!signedIn) {
+        if (!signedIn || !idToken) {
             toast({
-                title: 'Du er ikke logget inn',
+                title: 'Du er ikke logget inn.',
                 status: 'error',
                 isClosable: true,
             });
             return;
         }
 
-        // !signedIn implies idToken is not null
-        const { error } = await RegistrationAPI.deleteRegistration(registration.slug, registration.email, idToken!);
+        const { error } = await RegistrationAPI.deleteRegistration(registration.slug, registration.email, idToken);
 
         onClose();
 

--- a/frontend/src/components/user-row.tsx
+++ b/frontend/src/components/user-row.tsx
@@ -17,12 +17,12 @@ import {
     useDisclosure,
 } from '@chakra-ui/react';
 import { useState } from 'react';
-import { useSession } from 'next-auth/react';
 import type { StudentGroup } from '@api/dashboard';
 import DashboardAPI, { studentGroups } from '@api/dashboard';
 import type { User } from '@api/user';
 import capitalize from '@utils/capitalize';
 import { isErrorMessage } from '@utils/error';
+import useUser from '@hooks/use-user';
 
 interface Props {
     initialUser: User;
@@ -34,12 +34,12 @@ const UserRow = ({ initialUser }: Props) => {
     const toast = useToast();
     const { isOpen, onOpen, onClose } = useDisclosure();
 
-    const { data } = useSession();
+    const { idToken } = useUser();
 
     const handleChange = async (group: StudentGroup) => {
-        if (!data?.idToken) return;
+        if (!idToken) return;
 
-        const result = await DashboardAPI.updateMembership(user.email, group, data.idToken);
+        const result = await DashboardAPI.updateMembership(user.email, group, idToken);
 
         if (isErrorMessage(result)) {
             toast({

--- a/frontend/src/components/user-row.tsx
+++ b/frontend/src/components/user-row.tsx
@@ -22,7 +22,7 @@ import DashboardAPI, { studentGroups } from '@api/dashboard';
 import type { User } from '@api/user';
 import capitalize from '@utils/capitalize';
 import { isErrorMessage } from '@utils/error';
-import useUser from '@hooks/use-user';
+import useAuth from '@hooks/use-auth';
 
 interface Props {
     initialUser: User;
@@ -34,10 +34,18 @@ const UserRow = ({ initialUser }: Props) => {
     const toast = useToast();
     const { isOpen, onOpen, onClose } = useDisclosure();
 
-    const { idToken } = useUser();
+    const { signedIn, idToken } = useAuth();
 
     const handleChange = async (group: StudentGroup) => {
-        if (!idToken) return;
+        if (!signedIn || !idToken) {
+            toast({
+                title: 'Du er ikke logget inn.',
+                status: 'error',
+                duration: 5000,
+                isClosable: true,
+            });
+            return;
+        }
 
         const result = await DashboardAPI.updateMembership(user.email, group, idToken);
 

--- a/frontend/src/lib/api/reaction.ts
+++ b/frontend/src/lib/api/reaction.ts
@@ -19,7 +19,7 @@ const reactionDecoder = record({
 type Reaction = decodeType<typeof reactionDecoder>;
 
 const ReactionAPI = {
-    get: async (slug: string, idToken: string | undefined): Promise<Reaction | ErrorMessage> => {
+    get: async (slug: string, idToken: string | undefined | null): Promise<Reaction | ErrorMessage> => {
         try {
             if (!idToken) {
                 return { message: 'No token.' };
@@ -46,10 +46,10 @@ const ReactionAPI = {
             return { message: 'Noe gikk galt. Prøv igjen senere.' };
         }
     },
-    post: async (
+    put: async (
         slug: string,
         reaction: ReactionType,
-        idToken: string | undefined,
+        idToken: string | undefined | null,
     ): Promise<Reaction | ErrorMessage> => {
         try {
             if (!idToken) {

--- a/frontend/src/lib/api/reaction.ts
+++ b/frontend/src/lib/api/reaction.ts
@@ -19,12 +19,8 @@ const reactionDecoder = record({
 type Reaction = decodeType<typeof reactionDecoder>;
 
 const ReactionAPI = {
-    get: async (slug: string, idToken: string | undefined | null): Promise<Reaction | ErrorMessage> => {
+    get: async (slug: string, idToken: string): Promise<Reaction | ErrorMessage> => {
         try {
-            if (!idToken) {
-                return { message: 'No token.' };
-            }
-
             const { data, status } = await axios.get(`${BACKEND_URL}/reaction/${slug}`, {
                 params: { slug },
                 headers: {
@@ -46,11 +42,7 @@ const ReactionAPI = {
             return { message: 'Noe gikk galt. Prøv igjen senere.' };
         }
     },
-    put: async (
-        slug: string,
-        reaction: ReactionType,
-        idToken: string | undefined | null,
-    ): Promise<Reaction | ErrorMessage> => {
+    put: async (slug: string, reaction: ReactionType, idToken: string): Promise<Reaction | ErrorMessage> => {
         try {
             if (!idToken) {
                 return { message: 'No token.' };

--- a/frontend/src/lib/hooks/use-auth.tsx
+++ b/frontend/src/lib/hooks/use-auth.tsx
@@ -72,7 +72,7 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
     );
 };
 
-const useUser = (): HookObject => useContext(UserContext);
+const useAuth = (): HookObject => useContext(UserContext);
 
-export default useUser;
+export default useAuth;
 export { UserProvider };

--- a/frontend/src/lib/hooks/use-auth.tsx
+++ b/frontend/src/lib/hooks/use-auth.tsx
@@ -3,7 +3,7 @@ import { useSession } from 'next-auth/react';
 import { type User, UserAPI } from '@api/user';
 import { isErrorMessage, type ErrorMessage } from '@utils/error';
 
-interface HookObject {
+interface Auth {
     user: User | null;
     idToken: string | null;
     signedIn: boolean;
@@ -12,7 +12,7 @@ interface HookObject {
     setUser: (user: User) => void;
 }
 
-const UserContext = createContext<HookObject>({
+const AuthContext = createContext<Auth>({
     user: null,
     idToken: null,
     signedIn: false,
@@ -21,7 +21,7 @@ const UserContext = createContext<HookObject>({
     setUser: () => {},
 });
 
-const UserProvider = ({ children }: { children: ReactNode }) => {
+const AuthProvider = ({ children }: { children: ReactNode }) => {
     const { data: session, status } = useSession();
     const [user, setUser] = useState<User | null>(null);
     const [idToken, setIdToken] = useState<string | null>(session?.idToken ?? null);
@@ -57,7 +57,7 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
     }, [session]);
 
     return (
-        <UserContext.Provider
+        <AuthContext.Provider
             value={{
                 signedIn,
                 user,
@@ -68,11 +68,11 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
             }}
         >
             {children}
-        </UserContext.Provider>
+        </AuthContext.Provider>
     );
 };
 
-const useAuth = (): HookObject => useContext(UserContext);
+const useAuth = (): Auth => useContext(AuthContext);
 
 export default useAuth;
-export { UserProvider };
+export { AuthProvider };

--- a/frontend/src/lib/hooks/use-user.tsx
+++ b/frontend/src/lib/hooks/use-user.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState, createContext, useContext, type ReactNode } from 'react';
+import { useSession } from 'next-auth/react';
+import { type User, UserAPI } from '@api/user';
+import { isErrorMessage, type ErrorMessage } from '@utils/error';
+
+interface HookObject {
+    user: User | null;
+    signedIn: boolean;
+    loading: boolean;
+    error: ErrorMessage | null;
+    setUser: (user: User) => void;
+}
+
+const UserContext = createContext<HookObject>({
+    user: null,
+    signedIn: false,
+    loading: true,
+    error: null,
+    setUser: () => {},
+});
+
+const UserProvider = ({ children }: { children: ReactNode }) => {
+    const { data: session, status } = useSession();
+    const [user, setUser] = useState<User | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<ErrorMessage | null>(null);
+
+    useEffect(() => {
+        const fetchUser = async () => {
+            if (!session?.user?.email || !session.user.name || !session.idToken) {
+                setLoading(false);
+                return;
+            }
+            setLoading(true);
+
+            const result = await UserAPI.getUser(session.user.email, session.user.name, session.idToken);
+
+            if (isErrorMessage(result)) {
+                setError(result);
+            } else {
+                setUser(result);
+            }
+            setLoading(false);
+        };
+        void fetchUser();
+    }, [session]);
+
+    return (
+        <UserContext.Provider
+            value={{
+                signedIn: status === 'authenticated' && user !== null,
+                user,
+                loading,
+                error,
+                setUser,
+            }}
+        >
+            {children}
+        </UserContext.Provider>
+    );
+};
+
+const useUser = (): HookObject => useContext(UserContext);
+
+export default useUser;
+export { UserProvider };

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -7,7 +7,7 @@ import Fonts from '@styles/fonts';
 import theme from '@styles/theme';
 import Layout from '@components/layout';
 import { LanguageProvider } from '@hooks/use-language';
-import { UserProvider } from '@hooks/use-auth';
+import { AuthProvider } from '@hooks/use-auth';
 
 const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps<SessionProviderProps>): JSX.Element => {
     const router = useRouter();
@@ -15,7 +15,7 @@ const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps<Sessi
     return (
         <LanguageProvider>
             <SessionProvider session={session}>
-                <UserProvider>
+                <AuthProvider>
                     <ChakraProvider theme={theme}>
                         <NextNProgress
                             color="#29D"
@@ -29,7 +29,7 @@ const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps<Sessi
                             <Component {...pageProps} key={router} />
                         </Layout>
                     </ChakraProvider>
-                </UserProvider>
+                </AuthProvider>
             </SessionProvider>
         </LanguageProvider>
     );

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,10 +1,8 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import { SessionProvider, type SessionProviderProps } from 'next-auth/react';
-import { getMonth } from 'date-fns';
 import type { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
 import NextNProgress from 'nextjs-progressbar';
-import Snowfall from 'react-snowfall';
 import Fonts from '@styles/fonts';
 import theme from '@styles/theme';
 import Layout from '@components/layout';
@@ -13,7 +11,6 @@ import { UserProvider } from '@hooks/use-auth';
 
 const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps<SessionProviderProps>): JSX.Element => {
     const router = useRouter();
-    const SSR = typeof window === 'undefined'; //Used to disable rendering of animated component SS
 
     return (
         <LanguageProvider>
@@ -27,7 +24,6 @@ const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps<Sessi
                             height={4}
                             options={{ showSpinner: false }}
                         />
-                        {!SSR && getMonth(new Date()) === 11 && <Snowfall snowflakeCount={200} color="#ffffff" />}
                         <Fonts />
                         <Layout>
                             <Component {...pageProps} key={router} />

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import Fonts from '@styles/fonts';
 import theme from '@styles/theme';
 import Layout from '@components/layout';
 import { LanguageProvider } from '@hooks/use-language';
+import { UserProvider } from '@hooks/use-user';
 
 const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps<SessionProviderProps>): JSX.Element => {
     const router = useRouter();
@@ -17,20 +18,22 @@ const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps<Sessi
     return (
         <LanguageProvider>
             <SessionProvider session={session}>
-                <ChakraProvider theme={theme}>
-                    <NextNProgress
-                        color="#29D"
-                        startPosition={0.15}
-                        stopDelayMs={200}
-                        height={4}
-                        options={{ showSpinner: false }}
-                    />
-                    {!SSR && getMonth(new Date()) === 11 && <Snowfall snowflakeCount={200} color="#ffffff" />}
-                    <Fonts />
-                    <Layout>
-                        <Component {...pageProps} key={router} />
-                    </Layout>
-                </ChakraProvider>
+                <UserProvider>
+                    <ChakraProvider theme={theme}>
+                        <NextNProgress
+                            color="#29D"
+                            startPosition={0.15}
+                            stopDelayMs={200}
+                            height={4}
+                            options={{ showSpinner: false }}
+                        />
+                        {!SSR && getMonth(new Date()) === 11 && <Snowfall snowflakeCount={200} color="#ffffff" />}
+                        <Fonts />
+                        <Layout>
+                            <Component {...pageProps} key={router} />
+                        </Layout>
+                    </ChakraProvider>
+                </UserProvider>
             </SessionProvider>
         </LanguageProvider>
     );

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -9,7 +9,7 @@ import Fonts from '@styles/fonts';
 import theme from '@styles/theme';
 import Layout from '@components/layout';
 import { LanguageProvider } from '@hooks/use-language';
-import { UserProvider } from '@hooks/use-user';
+import { UserProvider } from '@hooks/use-auth';
 
 const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps<SessionProviderProps>): JSX.Element => {
     const router = useRouter();

--- a/frontend/src/pages/dashboard/brukere.tsx
+++ b/frontend/src/pages/dashboard/brukere.tsx
@@ -16,7 +16,6 @@ import {
 } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import { useEffect, useState } from 'react';
-import { useSession } from 'next-auth/react';
 import Section from '@components/section';
 import SEO from '@components/seo';
 import UserRow from '@components/user-row';
@@ -24,13 +23,14 @@ import type { ErrorMessage } from '@utils/error';
 import { isErrorMessage } from '@utils/error';
 import type { User } from '@api/user';
 import { UserAPI } from '@api/user';
+import useUser from '@hooks/use-user';
 
 const AdminUserPage = () => {
     const [users, setUsers] = useState<Array<User>>();
     const [error, setError] = useState<ErrorMessage | null>();
     const [loading, setLoading] = useState<boolean>(true);
 
-    const idToken = useSession().data?.idToken;
+    const { idToken } = useUser();
 
     useEffect(() => {
         const fetchUsers = async () => {

--- a/frontend/src/pages/dashboard/brukere.tsx
+++ b/frontend/src/pages/dashboard/brukere.tsx
@@ -23,20 +23,20 @@ import type { ErrorMessage } from '@utils/error';
 import { isErrorMessage } from '@utils/error';
 import type { User } from '@api/user';
 import { UserAPI } from '@api/user';
-import useUser from '@hooks/use-user';
+import useAuth from '@hooks/use-auth';
 
 const AdminUserPage = () => {
     const [users, setUsers] = useState<Array<User>>();
     const [error, setError] = useState<ErrorMessage | null>();
     const [loading, setLoading] = useState<boolean>(true);
 
-    const { idToken } = useUser();
+    const { signedIn, idToken, error: userError } = useAuth();
 
     useEffect(() => {
         const fetchUsers = async () => {
             setError(null);
 
-            if (!idToken) {
+            if (!signedIn || !idToken) {
                 setLoading(false);
                 setError({ message: 'Du må være logget inn for å se denne siden.' });
                 return;
@@ -54,16 +54,16 @@ const AdminUserPage = () => {
         };
 
         void fetchUsers();
-    }, [idToken]);
+    }, [idToken, signedIn]);
 
     return (
         <>
             <SEO title="Administrer brukere" />
             <Section>
-                {error && (
+                {(error || userError) && (
                     <Center flexDirection="column" gap="5" py="10">
                         <Heading>En feil har skjedd.</Heading>
-                        <Text>{error.message}</Text>
+                        <Text>{error?.message ?? userError?.message}</Text>
                         <Button>
                             <NextLink href="/" passHref>
                                 <Link>Tilbake til forsiden</Link>

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -12,13 +12,9 @@ import {
 } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import { useEffect, useState } from 'react';
-import { useSession } from 'next-auth/react';
 import Section from '@components/section';
 import SEO from '@components/seo';
-import type { ErrorMessage } from '@utils/error';
-import { isErrorMessage } from '@utils/error';
-import type { User } from '@api/user';
-import { UserAPI } from '@api/user';
+import useUser from '@hooks/use-user';
 
 const adminRoutes = [
     {
@@ -34,32 +30,10 @@ const adminRoutes = [
 ];
 
 const DashboardPage = () => {
-    const [user, setUser] = useState<User | null>();
-    const [error, setError] = useState<ErrorMessage>();
-    const [loading, setLoading] = useState<boolean>(true);
+    const { user, loading, error } = useUser();
     const [isWebkom, setIsWebkom] = useState<boolean>(false);
 
-    const { data } = useSession();
-
     const bg = useColorModeValue('gray.200', 'gray.800');
-
-    useEffect(() => {
-        const fetchUser = async () => {
-            if (!data?.user?.email || !data.user.name || !data.idToken) return;
-
-            const result = await UserAPI.getUser(data.user.email, data.user.name, data.idToken);
-
-            if (isErrorMessage(result)) {
-                setError(result);
-            } else {
-                setUser(result);
-            }
-
-            setLoading(false);
-        };
-
-        void fetchUser();
-    }, [data]);
 
     useEffect(() => {
         if (user) {

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -14,7 +14,8 @@ import NextLink from 'next/link';
 import { useEffect, useState } from 'react';
 import Section from '@components/section';
 import SEO from '@components/seo';
-import useUser from '@hooks/use-user';
+import ErrorBox from '@components/error-box';
+import useAuth from '@hooks/use-auth';
 
 const adminRoutes = [
     {
@@ -30,7 +31,7 @@ const adminRoutes = [
 ];
 
 const DashboardPage = () => {
-    const { user, loading, error } = useUser();
+    const { user, loading, signedIn, error } = useAuth();
     const [isWebkom, setIsWebkom] = useState<boolean>(false);
 
     const bg = useColorModeValue('gray.200', 'gray.800');
@@ -45,17 +46,19 @@ const DashboardPage = () => {
         <>
             <SEO title="Dashboard" />
             <Section>
-                {error && (
-                    <Center flexDirection="column" gap="5" py="10">
-                        <Heading>En feil har skjedd.</Heading>
-                        <Text>Du har ikke tilgang til denne siden.</Text>
-                        <Button>
-                            <NextLink href="/" passHref>
-                                <Link>Tilbake til forsiden</Link>
-                            </NextLink>
-                        </Button>
-                    </Center>
-                )}
+                {!signedIn ||
+                    (!isWebkom && (
+                        <Center flexDirection="column" gap="5" py="10">
+                            <Heading>En feil har skjedd.</Heading>
+                            <Text>Du har ikke tilgang til denne siden.</Text>
+                            <Button>
+                                <NextLink href="/" passHref>
+                                    <Link>Tilbake til forsiden</Link>
+                                </NextLink>
+                            </Button>
+                        </Center>
+                    ))}
+                {error && <ErrorBox error={error.message} />}
                 {loading && (
                     <Center flexDirection="column" gap="5" py="10">
                         <Heading>Laster inn...</Heading>

--- a/frontend/src/pages/dashboard/tilbakemeldinger.tsx
+++ b/frontend/src/pages/dashboard/tilbakemeldinger.tsx
@@ -20,7 +20,7 @@ import type { Feedback } from '@api/feedback';
 import { FeedbackAPI } from '@api/feedback';
 import { type ErrorMessage, isErrorMessage } from '@utils/error';
 import FeedbackEntry from '@components/feedback-entry';
-import useUser from '@hooks/use-user';
+import useAuth from '@hooks/use-auth';
 
 const FeedbackPage = () => {
     const [feedbacks, setFeedbacks] = useState<Array<Feedback>>();
@@ -31,13 +31,13 @@ const FeedbackPage = () => {
 
     const gridColumns = [1, null, null, null, 2];
 
-    const { idToken } = useUser();
+    const { signedIn, idToken } = useAuth();
 
     useEffect(() => {
         const getFeedbacks = async () => {
             setError(null);
 
-            if (!idToken) {
+            if (!signedIn || !idToken) {
                 setLoading(false);
                 setError({ message: 'Du må være logget inn for å se denne siden.' });
                 return;
@@ -55,17 +55,16 @@ const FeedbackPage = () => {
         };
 
         void getFeedbacks();
-    }, [idToken]);
+    }, [idToken, signedIn]);
 
     const handleDelete = async (id: number) => {
-        if (!idToken) {
+        if (!signedIn || !idToken) {
             toast({
                 title: 'Kunne ikke slette tilbakemelding',
                 description: 'Du må være logget inn for å slette en tilbakemelding.',
                 status: 'error',
                 duration: 5000,
             });
-
             return;
         }
 
@@ -82,14 +81,13 @@ const FeedbackPage = () => {
     };
 
     const handleUpdate = async (feedback: Feedback) => {
-        if (!idToken) {
+        if (!signedIn || !idToken) {
             toast({
                 title: 'Kunne ikke markere tilbakemelding som lest',
                 description: 'Du må være logget inn for å markere en tilbakemelding som lest.',
                 status: 'error',
                 duration: 5000,
             });
-
             return;
         }
 

--- a/frontend/src/pages/dashboard/tilbakemeldinger.tsx
+++ b/frontend/src/pages/dashboard/tilbakemeldinger.tsx
@@ -14,13 +14,13 @@ import {
 } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import NextLink from 'next/link';
-import { useSession } from 'next-auth/react';
 import Section from '@components/section';
 import SEO from '@components/seo';
 import type { Feedback } from '@api/feedback';
 import { FeedbackAPI } from '@api/feedback';
 import { type ErrorMessage, isErrorMessage } from '@utils/error';
 import FeedbackEntry from '@components/feedback-entry';
+import useUser from '@hooks/use-user';
 
 const FeedbackPage = () => {
     const [feedbacks, setFeedbacks] = useState<Array<Feedback>>();
@@ -31,7 +31,7 @@ const FeedbackPage = () => {
 
     const gridColumns = [1, null, null, null, 2];
 
-    const idToken = useSession().data?.idToken;
+    const { idToken } = useUser();
 
     useEffect(() => {
         const getFeedbacks = async () => {

--- a/frontend/src/pages/event/[slug].tsx
+++ b/frontend/src/pages/event/[slug].tsx
@@ -5,7 +5,6 @@ import { parseISO, format, formatISO, isBefore, isAfter, isFuture } from 'date-f
 import { Center, Divider, Grid, GridItem, Heading, LinkBox, LinkOverlay, Text } from '@chakra-ui/react';
 import { nb, enUS } from 'date-fns/locale';
 import Image from 'next/image';
-import { useSession } from 'next-auth/react';
 import NextLink from 'next/link';
 import type { ErrorMessage } from '@utils/error';
 import useUser from '@hooks/use-user';
@@ -32,18 +31,17 @@ interface Props {
 }
 
 const HappeningPage = ({ happening, happeningInfo, date, error }: Props): JSX.Element => {
-    const { data } = useSession();
     const regDate = parseISO(happening?.registrationDate ?? formatISO(new Date()));
     const regDeadline = parseISO(happening?.registrationDeadline ?? formatISO(new Date()));
     const isNorwegian = useLanguage();
-    const { signedIn } = useUser();
+    const { signedIn, idToken } = useUser();
     const [regsList, setRegsList] = useState<Array<Registration>>([]);
     const [regsListError, setRegsListError] = useState<ErrorMessage | null>(null);
 
     useEffect(() => {
         const fetchRegs = async () => {
-            if (!happening || !data?.idToken) return;
-            const result = await RegistrationAPI.getRegistrations(happening.slug, data.idToken);
+            if (!happening || !idToken) return;
+            const result = await RegistrationAPI.getRegistrations(happening.slug, idToken);
 
             if (isErrorMessage(result)) {
                 setRegsListError(result);
@@ -53,7 +51,7 @@ const HappeningPage = ({ happening, happeningInfo, date, error }: Props): JSX.El
             }
         };
         void fetchRegs();
-    }, [happening, data?.idToken]);
+    }, [happening, idToken]);
 
     return (
         <>

--- a/frontend/src/pages/event/[slug].tsx
+++ b/frontend/src/pages/event/[slug].tsx
@@ -7,7 +7,7 @@ import { nb, enUS } from 'date-fns/locale';
 import Image from 'next/image';
 import NextLink from 'next/link';
 import type { ErrorMessage } from '@utils/error';
-import useUser from '@hooks/use-user';
+import useAuth from '@hooks/use-auth';
 import RegistrationsList from '@components/registrations-list';
 import type { Happening, HappeningInfo } from '@api/happening';
 import { HappeningAPI } from '@api/happening';
@@ -34,13 +34,13 @@ const HappeningPage = ({ happening, happeningInfo, date, error }: Props): JSX.El
     const regDate = parseISO(happening?.registrationDate ?? formatISO(new Date()));
     const regDeadline = parseISO(happening?.registrationDeadline ?? formatISO(new Date()));
     const isNorwegian = useLanguage();
-    const { signedIn, idToken } = useUser();
+    const { signedIn, idToken } = useAuth();
     const [regsList, setRegsList] = useState<Array<Registration>>([]);
     const [regsListError, setRegsListError] = useState<ErrorMessage | null>(null);
 
     useEffect(() => {
         const fetchRegs = async () => {
-            if (!happening || !idToken) return;
+            if (!happening || !signedIn || !idToken) return;
             const result = await RegistrationAPI.getRegistrations(happening.slug, idToken);
 
             if (isErrorMessage(result)) {
@@ -51,7 +51,7 @@ const HappeningPage = ({ happening, happeningInfo, date, error }: Props): JSX.El
             }
         };
         void fetchRegs();
-    }, [happening, idToken]);
+    }, [happening, idToken, signedIn]);
 
     return (
         <>

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -2,10 +2,10 @@ import { Spinner, Center } from '@chakra-ui/react';
 import Unauthorized from '@components/unauthorized';
 import ProfileInfo from '@components/profile-info';
 import SEO from '@components/seo';
-import useUser from '@hooks/use-user';
+import useAuth from '@hooks/use-auth';
 
 const ProfilePage = (): JSX.Element => {
-    const { loading, signedIn } = useUser();
+    const { loading, signedIn } = useAuth();
 
     return (
         <>

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -1,22 +1,22 @@
-import { useSession } from 'next-auth/react';
 import { Spinner, Center } from '@chakra-ui/react';
 import Unauthorized from '@components/unauthorized';
 import ProfileInfo from '@components/profile-info';
 import SEO from '@components/seo';
+import useUser from '@hooks/use-user';
 
 const ProfilePage = (): JSX.Element => {
-    const { status } = useSession();
+    const { loading, signedIn } = useUser();
 
     return (
         <>
-            <SEO title={status === 'authenticated' ? 'Min profil' : 'Logg inn'} />
-            {status === 'authenticated' && <ProfileInfo />}
-            {status === 'loading' && (
+            <SEO title={signedIn ? 'Min profil' : 'Logg inn'} />
+            {loading && (
                 <Center>
                     <Spinner />
                 </Center>
             )}
-            {status === 'unauthenticated' && <Unauthorized />}
+            {signedIn && <ProfileInfo />}
+            {!signedIn && <Unauthorized />}
         </>
     );
 };


### PR DESCRIPTION
Samler alt av ting man trenger fra brukeren et sted.

```typescript
const { user, setUser, loading, signedIn, idToken } = useUser();
```

`user`: standard `User`-objekt, kan være null
`setUser`: funksjon man kan bruke til å endre `User`-objektet, a la `setUser(newUser);`
`loading`: `true` hvis den laster inn brukeren, `false` ellers
`signedIn`: er brukeren logget inn?
`idToken`: `string` med `idToken`, kan være null

Hvis noen har en legende TypeScript-hack som får den til å skjønne at hvis `signedIn === true` så kan ikke `idToken` være null hadde det vært nice. Inntil videre kan vi bruke `idToken!`.