### PR TITLE
Fix email not showing if alternate email not defined

### DIFF
--- a/.github/workflows/docker_tests_and_previews.yaml
+++ b/.github/workflows/docker_tests_and_previews.yaml
@@ -152,7 +152,6 @@ jobs:
           SANITY_DATASET: testing
           NEXTAUTH_URL: http://localhost:3000
           NEXTAUTH_SECRET: very-secret-string-123
-          NEXTAUTH_URL: http://localhost:3000
           FEIDE_CLIENT_ID: ${{ secrets.FEIDE_CLIENT_ID }}
           FEIDE_CLIENT_SECRET: ${{ secrets.FEIDE_CLIENT_SECRET }}
           SIGN_IN_DISABLE_CHECK: true

--- a/.github/workflows/docker_tests_and_previews.yaml
+++ b/.github/workflows/docker_tests_and_previews.yaml
@@ -150,6 +150,7 @@ jobs:
           browser: firefox
         env:
           SANITY_DATASET: testing
+          NEXTAUTH_URL: http://localhost:3000
           NEXTAUTH_SECRET: very-secret-string-123
           NEXTAUTH_URL: http://localhost:3000
           FEIDE_CLIENT_ID: ${{ secrets.FEIDE_CLIENT_ID }}

--- a/frontend/src/components/registration-row.tsx
+++ b/frontend/src/components/registration-row.tsx
@@ -1,5 +1,3 @@
-// eslint-disable @typescript-eslint/prefer-nullish-coalescing
-
 import type { TableRowProps } from '@chakra-ui/react';
 import {
     Heading,
@@ -68,6 +66,7 @@ const RegistrationRow = ({ registration, questions, studentGroups }: Props) => {
             void router.replace(router.asPath, undefined, { scroll: false });
             toast({
                 title: 'Påmelding slettet!',
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 description: `Slettet påmeding med email '${registration.alternateEmail || registration.email}'.`,
                 isClosable: true,
             });
@@ -89,7 +88,9 @@ const RegistrationRow = ({ registration, questions, studentGroups }: Props) => {
                 data-cy={`reg-row-${registration.email}`}
                 key={JSON.stringify(registration)}
             >
+                {/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */}
                 <Td fontSize="md">{registration.alternateEmail || registration.email}</Td>
+                {/* eslint-enable @typescript-eslint/prefer-nullish-coalescing */}
                 <Td fontSize="md">{registration.name}</Td>
                 <Td fontSize="md">{registration.degree}</Td>
                 <Td fontSize="md">{registration.degreeYear}</Td>
@@ -136,6 +137,7 @@ const RegistrationRow = ({ registration, questions, studentGroups }: Props) => {
                     </ModalHeader>
                     <ModalCloseButton />
                     <ModalBody>
+                        {/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */}
                         <Heading
                             size="md"
                             pb="0.5rem"
@@ -143,6 +145,7 @@ const RegistrationRow = ({ registration, questions, studentGroups }: Props) => {
                         >{`Er du sikker på at du vil slette påmeldingen med email '${
                             registration.alternateEmail || registration.email
                         }'?`}</Heading>
+                        {/* eslint-enable @typescript-eslint/prefer-nullish-coalescing */}
                         <Text fontWeight="bold" py="0.5rem" lineHeight="1.5">
                             Den vil bli borte for alltid.
                         </Text>

--- a/frontend/src/components/registration-row.tsx
+++ b/frontend/src/components/registration-row.tsx
@@ -1,3 +1,5 @@
+// eslint-disable @typescript-eslint/prefer-nullish-coalescing
+
 import type { TableRowProps } from '@chakra-ui/react';
 import {
     Heading,
@@ -66,7 +68,7 @@ const RegistrationRow = ({ registration, questions, studentGroups }: Props) => {
             void router.replace(router.asPath, undefined, { scroll: false });
             toast({
                 title: 'Påmelding slettet!',
-                description: `Slettet påmeding med email '${registration.alternateEmail ?? registration.email}'.`,
+                description: `Slettet påmeding med email '${registration.alternateEmail || registration.email}'.`,
                 isClosable: true,
             });
         } else {
@@ -87,7 +89,7 @@ const RegistrationRow = ({ registration, questions, studentGroups }: Props) => {
                 data-cy={`reg-row-${registration.email}`}
                 key={JSON.stringify(registration)}
             >
-                <Td fontSize="md">{registration.alternateEmail ?? registration.email}</Td>
+                <Td fontSize="md">{registration.alternateEmail || registration.email}</Td>
                 <Td fontSize="md">{registration.name}</Td>
                 <Td fontSize="md">{registration.degree}</Td>
                 <Td fontSize="md">{registration.degreeYear}</Td>
@@ -139,7 +141,7 @@ const RegistrationRow = ({ registration, questions, studentGroups }: Props) => {
                             pb="0.5rem"
                             lineHeight="1.5"
                         >{`Er du sikker på at du vil slette påmeldingen med email '${
-                            registration.alternateEmail ?? registration.email
+                            registration.alternateEmail || registration.email
                         }'?`}</Heading>
                         <Text fontWeight="bold" py="0.5rem" lineHeight="1.5">
                             Den vil bli borte for alltid.


### PR DESCRIPTION
Var en bug der det ikke var noe epost i registration-row dersom man ikke hadde definert en alternativ epost.
Det var brukt en nullish coalescing operator som evaluater på enten `null` eller `undefined`. Det vi i stedet trenger her er en logical or (`||`) siden den evaluater på falsy verdier og `alternateEmail` er `''`.
