### PR TITLE
Fix download csv regs

### DIFF
--- a/frontend/src/pages/api/registration/index.ts
+++ b/frontend/src/pages/api/registration/index.ts
@@ -17,14 +17,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         if (req.method === 'GET') {
             try {
                 const params = new URLSearchParams({ download: 'y' }).toString();
-
                 const response = await fetch(`${BACKEND_URL}/registration/${slug}?${params}`, {
                     headers: {
                         Authorization: `Bearer ${JWT_TOKEN}`,
                     },
+                    redirect: 'follow',
                 });
 
-                const data = await response.json();
+                const data = await response.text();
 
                 res.setHeader('Content-Type', 'text/csv');
                 res.setHeader(


### PR DESCRIPTION
Fikset en bug i `fetch` for nedlasting av CSV-påmeldinger.
`fetch`-requesten failer i prod nå dersom man prøver å laste ned påmeldinger som csv.

Måtte sette `redirect: 'follow'` og bruke `response.text()` i stedet for `response.json()`.
