### PR TITLE
🔧 Refactor environment variables for backend

### DIFF
--- a/.github/workflows/destroy_backend_preview.yaml
+++ b/.github/workflows/destroy_backend_preview.yaml
@@ -43,6 +43,7 @@ jobs:
           TF_VAR_backend_image: '$IMAGE_NAME/backend:$BACKEND_TAG'
           TF_VAR_admin_key: ${{ secrets.ADMIN_KEY_DEV }}
           TF_VAR_auth_secret: ${{ secrets.AUTH_SECRET }}
+          TF_VAR_environment: preview
           ARM_CLIENT_ID: 225cb793-e592-482e-8612-2318bd5e0a6c
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: f16e6916-1e71-42a0-9df3-0246b805f432

--- a/.github/workflows/docker_push_deploy_dev.yaml
+++ b/.github/workflows/docker_push_deploy_dev.yaml
@@ -19,6 +19,7 @@ env:
   TF_VAR_backend_container_name: echo-web-backend-dev
   TF_VAR_admin_key: ${{ secrets.ADMIN_KEY_DEV }}
   TF_VAR_auth_secret: ${{ secrets.AUTH_SECRET }}
+  TF_VAR_environment: development
   ARM_CLIENT_ID: 225cb793-e592-482e-8612-2318bd5e0a6c
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_SUBSCRIPTION_ID: f16e6916-1e71-42a0-9df3-0246b805f432
@@ -101,8 +102,6 @@ jobs:
           cd terraform/dev
           terraform init
           terraform apply -auto-approve -lock-timeout=15m
-        env:
-          TF_VAR_environment: development
 
       - name: Redeploy new container
         if: steps.changed-files-tf.outputs.any_changed != 'true' && steps.changed-files-backend.any_changed == 'true'
@@ -111,5 +110,3 @@ jobs:
           terraform init
           terraform destroy -auto-approve -target=azurerm_container_group.echo_web_containers -lock-timeout=15m
           terraform apply -auto-approve -target=azurerm_container_group.echo_web_containers -lock-timeout=15m
-        env:
-          TF_VAR_environment: development

--- a/.github/workflows/docker_tests_and_previews.yaml
+++ b/.github/workflows/docker_tests_and_previews.yaml
@@ -137,6 +137,7 @@ jobs:
           docker compose up &
         env:
           BACKEND_TAG: ${{ steps.changed-files-backend.outputs.any_changed == 'true' && github.sha || 'latest' }}
+          ENVIRONMENT: preview
 
       - name: Run Cypress end-to-end tests
         if: steps.changed-files-frontend.outputs.any_changed == 'true' || steps.changed-files-backend.outputs.any_changed == 'true'
@@ -202,7 +203,7 @@ jobs:
           docker exec -i backend-database-1 pg_restore --verbose --clean --no-acl --no-owner -h localhost -U postgres -d postgres latest.dump || true
           docker compose -f backend/docker-compose.yaml up backend & (sleep 15 && docker kill backend-backend-1)
         env:
-          TEST_MIGRATION: true
+          MIGRATE_DB: true
           ADMIN_KEY: admin-passord
 
   backend_preview:
@@ -268,6 +269,7 @@ jobs:
           TF_VAR_db_password: ${{ secrets.DB_PASSWORD_DEV }}
           TF_VAR_backend_image: '${{ env.IMAGE_NAME }}/backend:${{ steps.env_vars.outputs.BACKEND_TAG }}'
           TF_VAR_auth_secret: ${{ secrets.AUTH_SECRET }}
+          TF_VAR_environment: preview
           ARM_CLIENT_ID: 225cb793-e592-482e-8612-2318bd5e0a6c
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: f16e6916-1e71-42a0-9df3-0246b805f432

--- a/.github/workflows/docker_tests_and_previews.yaml
+++ b/.github/workflows/docker_tests_and_previews.yaml
@@ -47,7 +47,7 @@ jobs:
           cd backend
           docker build \
             --cache-from "$IMAGE_NAME/backend:latest" \
-            -t "$IMAGE_NAME/backend:$GITHUB_SHA" \
+            -t "$IMAGE_NAME/backend:$TAG" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             .
           docker push "$IMAGE_NAME/backend" --all-tags
@@ -56,7 +56,7 @@ jobs:
 
   kotest_tests:
     runs-on: ubuntu-latest
-    needs: build_backend
+    needs: [build_backend]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -75,7 +75,7 @@ jobs:
 
       - name: Pull Docker image
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: docker pull "$IMAGE_NAME/backend:$GITHUB_SHA"
+        run: docker pull "$IMAGE_NAME/backend:$TAG"
 
       - name: Run Kotest tests with Docker Compose
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -124,7 +124,7 @@ jobs:
 
       - name: Backend changed, pull Docker image
         if: steps.changed-files-frontend.outputs.any_changed == 'true' && steps.changed-files-backend.outputs.any_changed == 'true'
-        run: docker pull "$IMAGE_NAME/backend:$GITHUB_SHA"
+        run: docker pull "$IMAGE_NAME/backend:$TAG"
 
       - name: Backend didn't change, pull Docker image
         if: steps.changed-files-frontend.outputs.any_changed == 'true' && steps.changed-files-backend.outputs.any_changed != 'true'
@@ -184,7 +184,7 @@ jobs:
 
       - name: Pull Docker image
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: docker pull "$IMAGE_NAME/backend:$GITHUB_SHA"
+        run: docker pull "$IMAGE_NAME/backend:$TAG"
 
       - name: Download database dump
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/restart_backend_preview.yaml
+++ b/.github/workflows/restart_backend_preview.yaml
@@ -19,12 +19,6 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           body-includes: '<!-- BACKEND PREVIEW BOT -->'
 
-      - name: Print comment ID & author
-        run: |
-          echo ${{ steps.fc.outputs.comment-id }}
-          echo ${{ steps.fc.outputs.comment-author }}
-          echo ${{ steps.fc.outputs.comment-body }}
-
       - name: Get formatted branch name, to get resource group & container group name
         id: env_vars
         if: contains(${{ steps.fc.outputs.comment_body }}, '- [x] check this box to restart the backend preview, if you are getting errors.')

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,11 +1,34 @@
-# Needed for backend.
-# Application will not run at all without this.
-ADMIN_KEY=key_here
+## Copy this file to one named '.env', and uncomment (remove #) a line to set a variable.
 
-# Needed for sending emails.
-SENDGRID_API_KEY=key_here
+## Sets the key used by server-side frontend to access protected routes.
+## Can be any string as long as the frontend and backend has the same value.
+## Application will not run at all without this.
+# ADMIN_KEY=key_here
 
-# Optional feature toggles.
-# These do not need to be defined.
-SEND_EMAIL_REGISTRATION=false   # default is false
-DISABLE_JWT_AUTH=false          # default is false
+
+## Optional variables, these do not need to be defined.
+
+## Needed for sending emails (set SEND_EMAIL_REGISTRATION=true to enable them).
+## Has no default value.
+# SENDGRID_API_KEY=key_here
+
+## Sends an email to the users email when they register.
+## Default is false.
+# SEND_EMAIL_REGISTRATION=false
+
+## Runs database migrations, independent of which environment you are in.
+## Default is false.
+# RUN_MIGRATION=false
+
+## Initializes database, see init() function in DatabaseHandler.kt for details.
+## Default is true.
+# INIT_DB=true
+
+## Max amount of connections the HikariCP connection pool can have.
+## Default is 20 for prod, and 10 for dev/preview.
+# MAX_POOL_SIZE=10
+
+## Whether or not to use JWT test configuration.
+## Default is false for production environment and true otherwise.
+## Note! Setting this to false if environment is preview has no effect.
+# USE_JWT_TEST=false

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -8,7 +8,6 @@ val postgres_version: String by project
 val hikari_version: String by project
 val kotest_version: String by project
 val flyway_version: String by project
-val sendgrid_version: String by project
 
 // Needed for Shadow
 project.setProperty("mainClassName", "no.uib.echo.ApplicationKt")

--- a/backend/docker-compose.kotest.yaml
+++ b/backend/docker-compose.kotest.yaml
@@ -6,7 +6,6 @@ services:
       target: build
       cache_from:
         - '${IMAGE_NAME:-echo-webkom/echo-web}/backend:${TAG:-latest}'
-    image: '${IMAGE_NAME:-echo-webkom/echo-web}/backend:${TAG:-latest}'
     # Don't start backend before database is up.
     depends_on:
       database:
@@ -18,10 +17,11 @@ services:
     command: ./gradlew test --build-cache --no-rebuild --no-daemon
     environment:
       DATABASE_URL: postgres://postgres:password@database/postgres
-      ENVIRONMENT: 'preview'
+      ENVIRONMENT: development
       AUTH_SECRET: ${AUTH_SECRET:-very_secret_string_123}
       ADMIN_KEY: ${ADMIN_KEY:?Must specify ADMIN_KEY in .env file or environment.}
       INIT_DB: false
+      USE_JWT_TEST: true
 
   database:
     image: postgres:13.8-alpine

--- a/backend/docker-compose.kotest.yaml
+++ b/backend/docker-compose.kotest.yaml
@@ -6,7 +6,7 @@ services:
       target: build
       cache_from:
         - '${IMAGE_NAME:-echo-webkom/echo-web}/backend:${TAG:-latest}'
-    image: '${IMAGE_NAME:-echo-webkom/echo-web}backend:${TAG:-latest}'
+    image: '${IMAGE_NAME:-echo-webkom/echo-web}/backend:${TAG:-latest}'
     # Don't start backend before database is up.
     depends_on:
       database:
@@ -18,13 +18,10 @@ services:
     command: ./gradlew test --build-cache --no-rebuild --no-daemon
     environment:
       DATABASE_URL: postgres://postgres:password@database/postgres
-      DISABLE_JWT_AUTH: true
-      SHOULD_INIT_DB: false
-      # Value of DEV doesn't matter, only that it's defined.
-      DEV: 'yes'
-      # Values from .env file
-      ADMIN_KEY: ${ADMIN_KEY:?Must specify ADMIN_KEY in .env file or environment.}
+      ENVIRONMENT: 'preview'
       AUTH_SECRET: ${AUTH_SECRET:-very_secret_string_123}
+      ADMIN_KEY: ${ADMIN_KEY:?Must specify ADMIN_KEY in .env file or environment.}
+      INIT_DB: false
 
   database:
     image: postgres:13.8-alpine

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -16,16 +16,16 @@ services:
       - '${PORT:-8080}:${PORT:-8080}'
     environment:
       DATABASE_URL: postgres://postgres:password@database/postgres
-      # Value of DEV doesn't matter, only that it's defined.
-      DEV: 'yes'
-      # Values from .env file
-      ADMIN_KEY: ${ADMIN_KEY:?Must specify ADMIN_KEY in .env file or environment.}
+      ENVIRONMENT: ${ENVIRONMENT:-development}
       AUTH_SECRET: ${AUTH_SECRET:-very_secret_string_123}
-      # Optional values from .env file
+      ADMIN_KEY: ${ADMIN_KEY:?Must specify ADMIN_KEY in .env file or environment.}
+      # Pass through optional values from .env file.
+      INIT_DB:
+      MIGRATE_DB:
+      USE_JWT_TEST:
+      MAX_POOL_SIZE:
       SENDGRID_API_KEY:
       SEND_EMAIL_REGISTRATION:
-      TEST_MIGRATION:
-      PORT:
 
   database:
     build:

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -5,5 +5,4 @@ postgres_version=42.5.1
 hikari_version=5.0.1
 kotest_version=5.5.4
 flyway_version=9.8.3
-sendgrid_version=4.8.0
 kotlin.code.style=official

--- a/backend/src/main/kotlin/no/uib/echo/Environment.kt
+++ b/backend/src/main/kotlin/no/uib/echo/Environment.kt
@@ -1,0 +1,19 @@
+package no.uib.echo
+enum class Environment {
+    PRODUCTION,
+    DEVELOPMENT,
+    PREVIEW,
+}
+
+fun String.toEnvironment(): Environment {
+    return when (val envLower = this.lowercase()) {
+        "production" -> Environment.PRODUCTION
+        "development" -> Environment.DEVELOPMENT
+        "preview" -> Environment.PREVIEW
+        else -> throw Exception("Invalid ENVIRONMENT variable. Got '$envLower'.")
+    }
+}
+
+data class FeatureToggles(
+    val sendEmailReg: Boolean,
+)

--- a/backend/src/main/kotlin/no/uib/echo/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/uib/echo/plugins/Routing.kt
@@ -7,6 +7,7 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
+import no.uib.echo.Environment
 import no.uib.echo.FeatureToggles
 import no.uib.echo.routes.feedbackRoutes
 import no.uib.echo.routes.happeningRoutes
@@ -18,7 +19,7 @@ import no.uib.echo.routes.userRoutes
 
 fun Application.configureRouting(
     featureToggles: FeatureToggles,
-    dev: Boolean = false,
+    env: Environment,
     sendGridApiKey: String? = null,
     audience: String,
     issuer: String,
@@ -34,9 +35,9 @@ fun Application.configureRouting(
     )
     happeningRoutes()
     feedbackRoutes()
-    userRoutes(dev, audience, issuer, secret, jwtConfig)
+    userRoutes(env, audience, issuer, secret, jwtConfig)
     reactionRoutes()
-    sanityRoutes(dev)
+    sanityRoutes(env)
     studentGroupRoutes()
 }
 

--- a/backend/src/main/kotlin/no/uib/echo/routes/SanityRoutes.kt
+++ b/backend/src/main/kotlin/no/uib/echo/routes/SanityRoutes.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import kotlinx.serialization.Serializable
+import no.uib.echo.Environment
 import no.uib.echo.SanityClient
 import no.uib.echo.schema.HappeningJson
 import no.uib.echo.schema.insertOrUpdateHappening
@@ -20,9 +21,9 @@ data class SanityResponse(
     val result: List<HappeningJson>
 )
 
-fun Application.sanityRoutes(dev: Boolean) {
+fun Application.sanityRoutes(env: Environment) {
     routing {
-        authenticate("auth-admin", optional = dev) {
+        authenticate("auth-admin", optional = env != Environment.PRODUCTION) {
             sanitySync()
         }
     }

--- a/backend/src/main/kotlin/no/uib/echo/routes/UserRoutes.kt
+++ b/backend/src/main/kotlin/no/uib/echo/routes/UserRoutes.kt
@@ -15,6 +15,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.routing
+import no.uib.echo.Environment
 import no.uib.echo.isEmailValid
 import no.uib.echo.schema.Degree
 import no.uib.echo.schema.StudentGroupMembership
@@ -36,14 +37,14 @@ import org.joda.time.DateTime
 import java.util.Date
 
 fun Application.userRoutes(
-    dev: Boolean = false,
+    env: Environment,
     audience: String,
     issuer: String,
     secret: String?,
     jwtConfig: String
 ) {
     routing {
-        getToken(dev, audience, issuer, secret)
+        getToken(env, audience, issuer, secret)
         authenticate(jwtConfig) {
             getUser()
             postUser()
@@ -294,7 +295,7 @@ fun Route.getAllUsers() {
 }
 
 /** Used for testing purposes */
-fun Route.getToken(dev: Boolean, audience: String, issuer: String, secret: String?) {
+fun Route.getToken(env: Environment, audience: String, issuer: String, secret: String?) {
     get("/token/{email}") {
         val email = call.parameters["email"]
 
@@ -303,8 +304,8 @@ fun Route.getToken(dev: Boolean, audience: String, issuer: String, secret: Strin
             return@get
         }
 
-        if (!dev || secret == null) {
-            call.respond(HttpStatusCode.Forbidden, "Only available in dev mode ! >:(")
+        if (env == Environment.PRODUCTION || secret == null) {
+            call.respond(HttpStatusCode.Forbidden, "Only available in dev or preview environment! >:(")
             return@get
         }
         val token =

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -1,31 +1,38 @@
 ktor {
     deployment {
+        # Set default port.
         port = 8080
+        # Overrides above if PORT is set.
         port = ${?PORT}
     }
     application {
         modules = [ no.uib.echo.ApplicationKt.module ]
     }
 
-    # Default values
-    testMigration = false
-    shouldInitDb = true
-    sendEmailRegistration = false
-
-    # Essential variables (crashes if not defined)
+    # Essential variables (server crashes if not defined).
     adminKey = ${ADMIN_KEY}
     databaseUrl = ${DATABASE_URL}
+    environment = ${ENVIRONMENT}
 
-    # Optional variables (note question mark notation)
-    dev = ${?DEV}
-    testMigration = ${?TEST_MIGRATION}
-    shouldInitDb = ${?SHOULD_INIT_DB}
+    # Default values for optional variables.
+    migrateDb = false
+    initDb = true
+    sendEmailRegistration = false
+    useJwtTest = false
+
+    # Optional variables, overrides above default values (note question mark notation).
+    migrateDb = ${?MIGRATE_DB}
+    initDb = ${?INIT_DB}
     sendEmailRegistration = ${?SEND_EMAIL_REGISTRATION}
+    useJwtTest = ${?USE_JWT_TEST}
+
+    # Optional variables with no default values.
     sendGridApiKey = ${?SENDGRID_API_KEY}
     maxPoolSize = ${?MAX_POOL_SIZE}
 }
 
 jwt {
+    # Optional, only required if not in production or if useJwtTest = true.
     secret = ${?AUTH_SECRET}
     issuer = "http://0.0.0.0:8080/"
     audience = "testing"

--- a/backend/src/test/kotlin/no/uib/echo/happening/DeleteHappeningTest.kt
+++ b/backend/src/test/kotlin/no/uib/echo/happening/DeleteHappeningTest.kt
@@ -9,6 +9,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.testApplication
 import no.uib.echo.DatabaseHandler
+import no.uib.echo.Environment
 import no.uib.echo.be
 import no.uib.echo.hap1
 import no.uib.echo.schema.StudentGroup
@@ -28,8 +29,8 @@ import kotlin.test.Test
 class DeleteHappeningTest {
     companion object {
         val db = DatabaseHandler(
-            dev = true,
-            testMigration = false,
+            env = Environment.PREVIEW,
+            migrateDb = false,
             dbUrl = URI(System.getenv("DATABASE_URL")),
             mbMaxPoolSize = null
         )

--- a/backend/src/test/kotlin/no/uib/echo/registration/DeleteRegistrationsTest.kt
+++ b/backend/src/test/kotlin/no/uib/echo/registration/DeleteRegistrationsTest.kt
@@ -17,6 +17,7 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.testApplication
 import no.uib.echo.DatabaseHandler
+import no.uib.echo.Environment
 import no.uib.echo.RegistrationResponse
 import no.uib.echo.RegistrationResponseJson
 import no.uib.echo.adminUser
@@ -54,8 +55,8 @@ import kotlin.test.Test
 class DeleteRegistrationsTest {
     companion object {
         val db = DatabaseHandler(
-            dev = true,
-            testMigration = false,
+            env = Environment.PREVIEW,
+            migrateDb = false,
             dbUrl = URI(System.getenv("DATABASE_URL")),
             mbMaxPoolSize = null
         )

--- a/backend/src/test/kotlin/no/uib/echo/registration/GetRegistrationsTest.kt
+++ b/backend/src/test/kotlin/no/uib/echo/registration/GetRegistrationsTest.kt
@@ -16,6 +16,7 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.testApplication
 import no.uib.echo.DatabaseHandler
+import no.uib.echo.Environment
 import no.uib.echo.RegistrationResponse
 import no.uib.echo.RegistrationResponseJson
 import no.uib.echo.adminUser
@@ -58,8 +59,8 @@ import kotlin.test.Test
 class GetRegistrationsTest {
     companion object {
         val db = DatabaseHandler(
-            dev = true,
-            testMigration = false,
+            env = Environment.PREVIEW,
+            migrateDb = false,
             dbUrl = URI(System.getenv("DATABASE_URL")),
             mbMaxPoolSize = null
         )

--- a/backend/src/test/kotlin/no/uib/echo/registration/PostRegistrationsTest.kt
+++ b/backend/src/test/kotlin/no/uib/echo/registration/PostRegistrationsTest.kt
@@ -15,6 +15,7 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.testApplication
 import no.uib.echo.DatabaseHandler
+import no.uib.echo.Environment
 import no.uib.echo.RegistrationResponse
 import no.uib.echo.RegistrationResponseJson
 import no.uib.echo.be
@@ -55,8 +56,8 @@ import kotlin.test.Test
 class PostRegistrationsTest {
     companion object {
         val db = DatabaseHandler(
-            dev = true,
-            testMigration = false,
+            env = Environment.PREVIEW,
+            migrateDb = false,
             dbUrl = URI(System.getenv("DATABASE_URL")),
             mbMaxPoolSize = null
         )

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,5 @@
+{
+    "github": {
+        "silent": true
+    }
+}

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -106,7 +106,8 @@ resource "azurerm_container_group" "echo_web_containers" {
     memory = 0.5
 
     environment_variables = {
-      "MAX_POOL_SIZE" = "5"
+      "ENVIRONMENT"  = var.environment
+      "USE_JWT_TEST" = "true"
     }
 
     secure_environment_variables = {

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -106,8 +106,9 @@ resource "azurerm_container_group" "echo_web_containers" {
     memory = 0.5
 
     environment_variables = {
-      "ENVIRONMENT"  = var.environment
-      "USE_JWT_TEST" = "true"
+      "MAX_POOL_SIZE" = 7
+      "ENVIRONMENT"   = var.environment
+      "USE_JWT_TEST"  = "true"
     }
 
     secure_environment_variables = {

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -10,7 +10,12 @@ variable "location" {
 
 variable "environment" {
   type        = string
-  description = "Tags the resources with the environment."
+  description = "Tags the resources with the environment, and sets backend environment."
+
+  validation {
+    condition     = contains(["production", "development", "preview"], var.environment)
+    error_message = "Valid values for environment are: 'production', 'development' and 'preview'."
+  }
 }
 
 variable "db_user" {

--- a/terraform/preview/main.tf
+++ b/terraform/preview/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_resource_group" "echo_web" {
   location = var.location
 
   tags = {
-    environment = "preview"
+    environment = var.environment
   }
 }
 
@@ -46,7 +46,7 @@ resource "azurerm_storage_account" "caddy_preview_storage" {
   enable_https_traffic_only = true
 
   tags = {
-    "environment" = "preview"
+    "environment" = var.environment
   }
 }
 
@@ -74,8 +74,7 @@ resource "azurerm_container_group" "echo_web_preview" {
     memory = 0.5
 
     environment_variables = {
-      "MAX_POOL_SIZE" = "10"
-      "DEV"           = "jaj"
+      "ENVIRONMENT" = var.environment
     }
 
     secure_environment_variables = {
@@ -146,7 +145,7 @@ resource "azurerm_container_group" "echo_web_preview" {
   }
 
   tags = {
-    "environment" = "preview"
+    "environment" = var.environment
   }
 }
 

--- a/terraform/preview/main.tf
+++ b/terraform/preview/main.tf
@@ -74,7 +74,8 @@ resource "azurerm_container_group" "echo_web_preview" {
     memory = 0.5
 
     environment_variables = {
-      "ENVIRONMENT" = var.environment
+      "MAX_POOL_SIZE" = 7
+      "ENVIRONMENT"   = var.environment
     }
 
     secure_environment_variables = {

--- a/terraform/preview/variables.tf
+++ b/terraform/preview/variables.tf
@@ -8,6 +8,16 @@ variable "location" {
   description = "The Azure location where the resources should be created."
 }
 
+variable "environment" {
+  type        = string
+  description = "Tags the resources with the environment, and sets backend environment."
+
+  validation {
+    condition     = contains(["production", "development", "preview"], var.environment)
+    error_message = "Valid values for environment are: 'production', 'development' and 'preview'."
+  }
+}
+
 variable "db_password" {
   type        = string
   description = "The admin password for the database."


### PR DESCRIPTION
Byttet ut boolske `dev` med strengen `env`, som kan være `production`, `development` eller `preview`. Dette følger samme konvensjon som Vercel bruker med frontenden vår i Next.js.

Ref. tråd på Slack, så blir test-konfigurasjonen av JWT bare brukt om `env` er `preview`, eller om man setter `USE_JWT_TEST` til  `true`. Om man spinner opp backend lokalt med Docker, vil `env` være `development`, og vanlig JWT-konfigurasjon vil bli brukt.

Ryddet også opp i filene som har med miljøvariabler å gjøre, samt litt dokumentasjon og navneendringer for å gjøre ting lettere å forstå.

Har ikke testet alt 100%, så gjerne test selv lokalt. Dev og preview i Azure får vi se om funker når Actions kjører.