### PR TITLE
Fixed publishedOnce field, more user-friendly happening schema

### DIFF
--- a/backend/src/main/kotlin/no/uib/echo/routes/SanityRoutes.kt
+++ b/backend/src/main/kotlin/no/uib/echo/routes/SanityRoutes.kt
@@ -30,10 +30,18 @@ fun Application.sanityRoutes(env: Environment) {
 }
 
 fun Route.sanitySync() {
-    get("/sanity") {
+    get("/sanity/{dataset?}") {
+        val dataset = call.parameters["dataset"] ?: "production"
+        val validDatasets = listOf("production", "develop", "testing")
+
+        if (dataset !in validDatasets) {
+            call.respond(HttpStatusCode.BadRequest)
+            return@get
+        }
+
         val client = SanityClient(
             projectId = "pgq2pd26",
-            dataset = "production",
+            dataset = dataset,
             apiVersion = "v2021-10-21",
             useCdn = true
         )

--- a/cms/sanity.json
+++ b/cms/sanity.json
@@ -12,15 +12,11 @@
         "@sanity/default-layout",
         "@sanity/default-login",
         "@sanity/desk-tool",
+        "@sanity/vision",
         "markdown",
         "media",
         "color-picker"
     ],
-    "env": {
-        "development": {
-            "plugins": ["@sanity/vision"]
-        }
-    },
     "parts": [
         {
             "name": "part:@sanity/base/schema",

--- a/cms/schemas/Happening.js
+++ b/cms/schemas/Happening.js
@@ -17,6 +17,11 @@ export default {
     },
     fields: [
         {
+            name: 'publishedOnce',
+            type: 'boolean',
+            hidden: true,
+        },
+        {
             name: 'title',
             title: 'Tittel',
             validation: (Rule) => Rule.required(),

--- a/cms/schemas/Post.js
+++ b/cms/schemas/Post.js
@@ -14,6 +14,11 @@ export default {
     },
     fields: [
         {
+            name: 'publishedOnce',
+            type: 'boolean',
+            hidden: true,
+        },
+        {
             name: 'title',
             title: 'Tittel',
             validation: (Rule) => Rule.required(),


### PR DESCRIPTION
Har gjort brukerflyten for å opprette arrangementer i sanity mye lettere å bruke. I stedet for at man blir satt inn i et form med masse forskjellige felt som har avhengigheter til hverandre, så dukker ting opp etterhvert som man fyller ut ulike felter.

Fiksa også opp i `publishedOnce`-logikken slik at den kun applier på dokumenter som inneholder slugs, i tillegg til at det ikke vises en feilmelding dersom den er definert.

I tillegg til dette har jeg gjort om på backend-endepunktet for å hente ned sanity-data til å inkludere datasett i URLen. dvs. at ~`/sanity` ikke lenger er et gyldig endepunkt, men man må heller bruke `/sanity/production` f.eks~ Dersom man kaller `/sanity/develop` vil den bruke `develop`, og dersom man kaller `/sanity` uten noe datasett vil den defaulte til `production`.  Dette gjør det lettere å bruke endepunktet lokalt, slik at man slipper å endre koden.