### PR TITLE
✨ Add rate limiting for backend

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation("io.ktor:ktor-server-cors:$ktor_version")
     implementation("io.ktor:ktor-server-auth:$ktor_version")
     implementation("io.ktor:ktor-server-auth-jwt:$ktor_version")
+    implementation("io.ktor:ktor-server-rate-limit:$ktor_version")
 
     implementation("io.ktor:ktor-client-core:$ktor_version")
     implementation("io.ktor:ktor-client-cio:$ktor_version")

--- a/backend/src/main/kotlin/no/uib/echo/Application.kt
+++ b/backend/src/main/kotlin/no/uib/echo/Application.kt
@@ -5,6 +5,7 @@ import io.ktor.server.netty.EngineMain
 import no.uib.echo.plugins.configureAuthentication
 import no.uib.echo.plugins.configureCORS
 import no.uib.echo.plugins.configureContentNegotiation
+import no.uib.echo.plugins.configureRateLimit
 import no.uib.echo.plugins.configureRouting
 import java.net.URI
 
@@ -65,4 +66,5 @@ fun Application.module() {
         secret = secret,
         jwtConfig = jwtConfig
     )
+    configureRateLimit()
 }

--- a/backend/src/main/kotlin/no/uib/echo/plugins/RateLimit.kt
+++ b/backend/src/main/kotlin/no/uib/echo/plugins/RateLimit.kt
@@ -1,0 +1,14 @@
+package no.uib.echo.plugins
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.ratelimit.RateLimit
+import kotlin.time.Duration.Companion.seconds
+
+fun Application.configureRateLimit() {
+    install(RateLimit) {
+        global {
+            rateLimiter(limit = 200, refillPeriod = 60.seconds)
+        }
+    }
+}

--- a/backend/src/test/kotlin/no/uib/echo/status/GetStatusTest.kt
+++ b/backend/src/test/kotlin/no/uib/echo/status/GetStatusTest.kt
@@ -14,4 +14,16 @@ class GetStatusTest {
 
             res.status shouldBe HttpStatusCode.OK
         }
+
+    @Test
+    fun `Should rate limit after 200 requests`() =
+        testApplication {
+            for (i in 1..200) {
+                val res = client.get("/status")
+                res.status shouldBe HttpStatusCode.OK
+            }
+
+            val res = client.get("/status")
+            res.status shouldBe HttpStatusCode.TooManyRequests
+        }
 }

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -109,6 +109,7 @@ resource "azurerm_container_group" "echo_web_containers" {
       "MAX_POOL_SIZE" = 7
       "ENVIRONMENT"   = var.environment
       "USE_JWT_TEST"  = "true"
+      "MIGRATE_DB"    = "true"
     }
 
     secure_environment_variables = {


### PR DESCRIPTION
Gjør at man ikke kan spamme backend med requests, 200 per 60 sekunder er maks. Fikset også at dev-backend gir 500 når man logger inn.