### PR TITLE
🗃 Handle database initialization and migration better

### DIFF
--- a/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
+++ b/backend/src/main/kotlin/no/uib/echo/DatabaseHandler.kt
@@ -27,8 +27,8 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.joda.time.DateTime
 import java.net.URI
 
-private const val DEFAULT_DEV_POOL_SIZE = 10
-private const val DEFAULT_PROD_POOL_SIZE = 50
+private const val DEFAULT_DEV_POOL_SIZE = 7
+private const val DEFAULT_PROD_POOL_SIZE = 20
 
 val tables: Array<Table> = arrayOf(
     Happening,
@@ -53,7 +53,7 @@ class DatabaseHandler(
     private val dbUrlStr = "jdbc:postgresql://${dbUrl.host}:${dbPort}${dbUrl.path}"
     private val dbUsername = dbUrl.userInfo.split(":")[0]
     private val dbPassword = dbUrl.userInfo.split(":")[1]
-    // MAX_POOL_SIZE takes precedence if it is not null, else we have defaults 20 and 10 for prod and dev/preview respectively.
+    // MAX_POOL_SIZE takes precedence if it is not null, else we have defaults for prod and dev/preview defined above.
     private val maxPoolSize =
         mbMaxPoolSize?.toIntOrNull()
             ?: if (env == Environment.PRODUCTION)
@@ -74,9 +74,15 @@ class DatabaseHandler(
         )
     }
 
-    private fun migrate() {
-        Flyway.configure().baselineOnMigrate(true).dataSource(dbUrlStr, dbUsername, dbPassword).load().migrate()
-    }
+    /*
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        IT'S VERY IMPORTANT THAT baselineVersion MATCHES THE LATEST VERSION,
+        GIVEN BY THE NAME OF THE SQL FILE IN src/main/resources/db/migration
+        WITH THE HIGHEST PREFIX. I.E., "V29__xyz_abc.sql" IS VERSION "29".
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    */
+    private val flyway: Flyway =
+        Flyway.configure().baselineVersion("27").dataSource(dbUrlStr, dbUsername, dbPassword).load()
 
     private val conn by lazy {
         Database.connect(dataSource())
@@ -86,20 +92,33 @@ class DatabaseHandler(
         // Need to use connection once to open.
         transaction(conn) {}
 
+        // Migrate and return if in prod
         if (env == Environment.PRODUCTION || migrateDb) {
-            migrate()
-        } else {
+            flyway.migrate()
+            return
+        }
+
+        // Try to migrate and return if in dev
+        if (env == Environment.DEVELOPMENT) {
             try {
-                transaction {
-                    SchemaUtils.create(*tables)
-                }
-                if (insertTestData) {
-                    insertTestData()
-                }
+                flyway.migrate()
+                return
             } catch (e: Exception) {
-                System.err.println("Error creating tables.")
+                System.err.println("Migration failed, will try to create tables & baseline instead.")
             }
         }
+
+        try {
+            transaction { SchemaUtils.create(*tables) }
+        } catch (e: Exception) {
+            System.err.println("Error creating tables, assuming they already exists.")
+        }
+
+        if (insertTestData) insertTestData()
+
+        flyway.baseline()
+        // Try to migrate as well to confirm we are good.
+        flyway.migrate()
     }
 
     private fun insertTestData() {

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -106,10 +106,8 @@ resource "azurerm_container_group" "echo_web_containers" {
     memory = 0.5
 
     environment_variables = {
-      "MAX_POOL_SIZE" = 7
       "ENVIRONMENT"   = var.environment
       "USE_JWT_TEST"  = "true"
-      "MIGRATE_DB"    = "true"
     }
 
     secure_environment_variables = {

--- a/terraform/preview/main.tf
+++ b/terraform/preview/main.tf
@@ -74,7 +74,6 @@ resource "azurerm_container_group" "echo_web_preview" {
     memory = 0.5
 
     environment_variables = {
-      "MAX_POOL_SIZE" = 7
       "ENVIRONMENT"   = var.environment
     }
 


### PR DESCRIPTION
### Tidligere har det vært to tilfeller:

- **Vi er i prod:** vi vet at databasen vår holder styr på alle migrasjoner og er oppdatert til siste versjon, så vi kan kjøre `flyway.migrate()` og alt skal funke.
- **Vi er i dev/lokalt/preview/osv**: databasen vår er helt fersk og vi bryr oss ikke om migrasjoner siden det ikke finnes noe data å migrere, så vi bare ber Exposed om å lage alle tabellene for oss med `SchemaUtils.create()`.

Problemet oppstår da hvis vi f.eks. skal deploye en ny database til Azure, og vi vil at den skal holde styr på migrasjoner. Om vi da kjører tilfelle nummer én, vil alt krasje siden Flyway ikke finner noe info om tidligere migrasjoner, siden databasen er helt tom. Tilfelle nummer to går jo heller ikke, siden da holder vi ikke styr på migrasjoner.

### Løsningen er:

- **Vi er i prod:** gjør samme som før.
- **Vi er i dev (altså lokalt eller i Azure):** prøv å kjør `flyway.migrate()`. Om dette ikke går, fortsett på punktet under.
- **Vi er i preview:** vi antar at databasen er tom, og lager alle tabellene, for å så kjøre `flyway.baseline()`. Det denne siste funksjonen gjør, er at den syncer databasen vår opp med den siste migrasjonen vi har, og lagrer info om den som Flyway kan hente ut senere. Da skal det fint være mulig å migrere databasen i fremtiden, helt automagisk via `flyway.migrate()`.

### TL;DR: fikser at uansett om du er i prod, dev eller preview, så stemmer tabellene i databasen overens med hvordan de er i koden.
