### PR TITLE
🐛 Fix registrations list stats edge cases & scaling

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,5 +6,6 @@ frontend/public/workbox-*.js*
 backend/build/*
 
 cms/dist/*
+cms/.sanity/*
 
 **/.terraform

--- a/frontend/src/components/registration-pie-chart.tsx
+++ b/frontend/src/components/registration-pie-chart.tsx
@@ -1,6 +1,6 @@
 import { type PieLabelRenderProps, PieChart, Pie, Cell, Tooltip } from 'recharts';
 import randomColor from 'randomcolor';
-import { Center, useColorModeValue } from '@chakra-ui/react';
+import { Center, useColorModeValue, useBreakpointValue } from '@chakra-ui/react';
 import { allDegrees } from '@utils/degree';
 import type { Registration } from '@api/registration';
 import capitalize from '@utils/capitalize';
@@ -13,6 +13,8 @@ interface Props {
 
 const RegistrationPieChart = ({ registrations, field }: Props) => {
     const textColor = useColorModeValue('black', 'white');
+    const chartSize = useBreakpointValue([375, 400, 700]) ?? 700;
+    const labelFontSize = useBreakpointValue([11, 16, 20]) ?? 20;
 
     const luminosity = 'bright';
 
@@ -73,7 +75,14 @@ const RegistrationPieChart = ({ registrations, field }: Props) => {
         const y = cy + radius * Math.sin(-midAngle * RADIAN);
 
         return (
-            <text x={x} y={y} fill={textColor} textAnchor={x > cx ? 'start' : 'end'} dominantBaseline="central">
+            <text
+                fontSize={labelFontSize}
+                x={x}
+                y={y}
+                fill={textColor}
+                textAnchor={x > cx ? 'start' : 'end'}
+                dominantBaseline="central"
+            >
                 {name}
             </text>
         );
@@ -81,8 +90,14 @@ const RegistrationPieChart = ({ registrations, field }: Props) => {
 
     return (
         <Center>
-            <PieChart width={500} height={500}>
-                <Pie data={regs} dataKey="value" label={renderCustomizedLabel} labelLine={false} outerRadius={140}>
+            <PieChart width={chartSize} height={chartSize}>
+                <Pie
+                    data={regs}
+                    dataKey="value"
+                    label={renderCustomizedLabel}
+                    labelLine={false}
+                    outerRadius={Math.floor(chartSize / 3.9)}
+                >
                     {regs.map((entry, index) => (
                         <Cell key={`cell-${index}`} fill={entry.color} fontWeight="bold" />
                     ))}

--- a/frontend/src/components/registrations-over-time.tsx
+++ b/frontend/src/components/registrations-over-time.tsx
@@ -1,0 +1,34 @@
+import { XAxis, YAxis, Tooltip, CartesianGrid, Line, LineChart, ResponsiveContainer } from 'recharts';
+import { format } from 'date-fns';
+
+interface Props {
+    data: Array<{ key: number; value: number }>;
+}
+
+const RegistrationsOverTime = ({ data }: Props) => {
+    return (
+        <ResponsiveContainer width="100%" height={400}>
+            <LineChart width={500} height={300} data={data}>
+                <XAxis
+                    dataKey="key"
+                    scale="linear"
+                    tickFormatter={(value) => format(value, 'HH:mm:ss')}
+                    domain={['dataMin', 'dataMax']}
+                />
+                <YAxis allowDecimals={false} domain={['dataMin', 'dataMax']} />
+                <Tooltip
+                    labelFormatter={(label) => format(label, 'dd.MM HH:mm:ss')}
+                    formatter={(value) => [value, 'Antall påmeldinger']}
+                    contentStyle={{
+                        backgroundColor: 'white',
+                        color: 'black',
+                    }}
+                />
+                <CartesianGrid strokeDasharray="3 3" scale="linear" />
+                <Line type="monotone" dataKey="value" stroke="#8884d8" strokeWidth="1.5" />
+            </LineChart>
+        </ResponsiveContainer>
+    );
+};
+
+export default RegistrationsOverTime;

--- a/frontend/src/pages/event/[slug].tsx
+++ b/frontend/src/pages/event/[slug].tsx
@@ -170,6 +170,9 @@ const HappeningPage = ({ happening, happeningInfo, date, error }: Props): JSX.El
                     {regsList.length > 0 && (
                         <RegistrationsList
                             registrations={regsList}
+                            registrationDate={
+                                happening.registrationDate ? parseISO(happening.registrationDate) : new Date()
+                            }
                             error={regsListError?.message ?? null}
                             title={happening.title}
                         />


### PR DESCRIPTION
- Håndterer nå at to påmeldinger skjer på samme millisekund, som var tilfelle for b.la. vinterballet.

- Separerte tidlig og vanlig påmelding inn i to grafer. Når de var på samme graf var grafen helt ubrukelig, siden tidsrammen mellom starten på tidlige og starten på vanlige påmeldinger ble så stor. Vanlig påmelding ble bare en rett strek oppover siden de skjer så fort.

![2022-12-30_19:38:12](https://user-images.githubusercontent.com/6720179/210104280-bec5c6e9-cf63-4aea-92d2-7728503feecf.png)

- Gjorde kakediagrammene mer responsive på mobil.

### Før
![2022-12-30_20:07:41](https://user-images.githubusercontent.com/6720179/210104431-6267239c-90ca-42af-9509-5f1f8dc200e7.png)

### Etter

![2022-12-30_20:06:47](https://user-images.githubusercontent.com/6720179/210104442-6bd16f4a-8316-4839-aa6a-4f2ee1ac3df5.png)

