### PR TITLE
🔧 Make Renovate pin devDeps & group azurerm updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,8 @@
     "prCreation": "not-pending",
     "ignoreDeps": ["openjdk", "node", "postgres"],
     "updateInternalDeps": true,
-    "additionalBranchPrefix": "{{parentDir}}-",
+    "additionalBranchPrefix": "{{#if (containsString depName 'azurerm')}}{{else}}{{parentDir}}-{{/if}}",
+    "rangeStrategy": "pin",
     "packageRules": [
         {
             "matchPackagePatterns": ["^org.jetbrains.exposed"],


### PR DESCRIPTION
Gjør slikt at Renovate pin'er devDependencies (altså endrer fra "^1.2.3" -> "1.2.3") og grupperer Terraform oppdateringer sammen (nå er de separate for main og preview).