### PR TITLE
🚨 Fix wrong linter warnings for date-fns imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ node_modules/
 **/*.tfstate*
 
 cms/.sanity
+
+**/yarn-error.log

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,9 +13,6 @@
         "test": "cypress run --component --config video=false,screenshotOnRunFailure=false"
     },
     "eslintConfig": {
-        "plugins": [
-            "import"
-        ],
         "parser": "@typescript-eslint/parser",
         "parserOptions": {
             "ecmaFeatures": {
@@ -65,7 +62,6 @@
             "import/no-useless-path-segments": "error",
             "import/order": "error",
             "import/exports-last": "error",
-            "import/no-unresolved": "error",
             "import/group-exports": "error",
             "import/prefer-default-export": "error",
             "@typescript-eslint/array-type": [
@@ -104,13 +100,6 @@
             "unicorn/numeric-separators-style": "off",
             "unicorn/no-array-reduce": "off",
             "unicorn/no-array-callback-reference": "off"
-        },
-        "settings": {
-            "import/resolver": {
-                "typescript": {
-                    "alwaysTryTypes": true
-                }
-            }
         }
     },
     "prettier": {

--- a/frontend/src/components/calendar-popup.tsx
+++ b/frontend/src/components/calendar-popup.tsx
@@ -12,10 +12,8 @@ import {
     LinkOverlay,
 } from '@chakra-ui/react';
 import { google, outlook, yahoo, ics } from 'calendar-link';
-/* eslint-disable import/no-duplicates */
 import { addHours, format } from 'date-fns';
 import { nb } from 'date-fns/locale';
-/* eslint-enable import/no-duplicates */
 import NextLink from 'next/link';
 import { FaFileDownload, FaGoogle, FaYahoo } from 'react-icons/fa';
 import { SiMicrosoftoutlook } from 'react-icons/si';

--- a/frontend/src/components/happening-key-info.tsx
+++ b/frontend/src/components/happening-key-info.tsx
@@ -1,8 +1,6 @@
 import { Flex, Stack, Text } from '@chakra-ui/react';
-/* eslint-disable import/no-duplicates */
 import { format, isToday, isPast } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
-/* eslint-enable import/no-duplicates */
 import { BiCalendar } from 'react-icons/bi';
 import type { Happening, SpotRange } from '@api/happening';
 import type { RegistrationCount } from '@api/registration';

--- a/frontend/src/components/header-logo.tsx
+++ b/frontend/src/components/header-logo.tsx
@@ -1,8 +1,6 @@
 import { Box, Flex, LinkBox, LinkOverlay, Text, useColorModeValue } from '@chakra-ui/react';
-/* eslint-disable import/no-duplicates */
 import { isFriday, isThursday, getDate, getHours, getMonth, getWeek, isMonday } from 'date-fns';
 import { nb } from 'date-fns/locale';
-/* eslint-enable import/no-duplicates */
 import Image from 'next/image';
 import NextLink from 'next/link';
 import { useEffect, useState } from 'react';

--- a/frontend/src/components/minute-list.tsx
+++ b/frontend/src/components/minute-list.tsx
@@ -13,10 +13,8 @@ import {
     Text,
     useColorModeValue,
 } from '@chakra-ui/react';
-/* eslint-disable import/no-duplicates */
 import { format } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
-/* eslint-enable import/no-duplicates */
 import NextLink from 'next/link';
 import { FaExternalLinkAlt } from 'react-icons/fa';
 import type { Minute } from '@api/minute';

--- a/frontend/src/components/registration-form.tsx
+++ b/frontend/src/components/registration-form.tsx
@@ -24,10 +24,8 @@ import type { SubmitHandler } from 'react-hook-form';
 import { FormProvider, useForm } from 'react-hook-form';
 import { MdOutlineArrowForward } from 'react-icons/md';
 import NextLink from 'next/link';
-/* eslint-disable import/no-duplicates */
 import { differenceInHours, format, isBefore, parseISO } from 'date-fns';
 import { enUS, nb } from 'date-fns/locale';
-/* eslint-enable import/no-duplicates */
 import CountdownButton from '@components/countdown-button';
 import type { Happening, HappeningType, Question } from '@api/happening';
 import type { RegFormValues } from '@api/registration';

--- a/frontend/src/pages/event/[slug].tsx
+++ b/frontend/src/pages/event/[slug].tsx
@@ -2,10 +2,8 @@ import type { ParsedUrlQuery } from 'querystring';
 import type { GetServerSideProps } from 'next';
 import { useEffect, useState } from 'react';
 import { Center, Divider, Grid, GridItem, Heading, LinkBox, LinkOverlay, Text } from '@chakra-ui/react';
-/* eslint-disable import/no-duplicates */
 import { parseISO, format, formatISO, isBefore, isAfter, isFuture } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
-/* eslint-enable import/no-duplicates */
 import Image from 'next/image';
 import NextLink from 'next/link';
 import type { ErrorMessage } from '@utils/error';

--- a/frontend/src/pages/jobb/[slug].tsx
+++ b/frontend/src/pages/jobb/[slug].tsx
@@ -1,9 +1,7 @@
 import type { ParsedUrlQuery } from 'querystring';
 import { Center, Divider, Grid, GridItem, Heading, LinkBox, LinkOverlay, Spinner, VStack } from '@chakra-ui/react';
-/* eslint-disable import/no-duplicates */
 import { format } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
-/* eslint-enable import/no-duplicates */
 import Markdown from 'markdown-to-jsx';
 import type { GetStaticPaths, GetStaticProps } from 'next';
 import Image from 'next/image';

--- a/frontend/src/pages/posts/[slug].tsx
+++ b/frontend/src/pages/posts/[slug].tsx
@@ -1,9 +1,7 @@
 import type { ParsedUrlQuery } from 'querystring';
 import { Box, Center, Divider, Flex, Heading, HStack, Spacer, Spinner } from '@chakra-ui/react';
-/* eslint-disable import/no-duplicates */
 import { format } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
-/* eslint-enable import/no-duplicates */
 import Markdown from 'markdown-to-jsx';
 import type { GetStaticPaths, GetStaticProps } from 'next';
 import { useRouter } from 'next/router';

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "devDependencies": {
         "eslint": "8.31.0",
         "eslint-config-prettier": "8.6.0",
-        "eslint-import-resolver-typescript": "3.5.3",
-        "eslint-plugin-import": "2.26.0",
         "eslint-plugin-prettier": "4.2.1",
         "husky": "8.0.3",
         "lint-staged": "13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6095,19 +6095,6 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
-eslint-import-resolver-typescript@3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.3.tgz#db5ed9e906651b7a59dd84870aaef0e78c663a05"
-  integrity sha512-njRcKYBc3isE42LaTcJNVANR3R99H9bAxBDMNDr2W7yq5gYPxbU3MkdhsQukxZ/Xg9C2vcyLlDsbKfRDg0QvCQ==
-  dependencies:
-    debug "^4.3.4"
-    enhanced-resolve "^5.10.0"
-    get-tsconfig "^4.2.0"
-    globby "^13.1.2"
-    is-core-module "^2.10.0"
-    is-glob "^4.0.3"
-    synckit "^0.8.4"
-
 eslint-import-resolver-typescript@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.2.tgz#9431acded7d898fd94591a08ea9eec3514c7de91"
@@ -6129,7 +6116,7 @@ eslint-module-utils@^2.7.3:
     debug "^3.2.7"
     find-up "^2.1.0"
 
-eslint-plugin-import@2.26.0, eslint-plugin-import@^2.26.0:
+eslint-plugin-import@^2.26.0:
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
   integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==


### PR DESCRIPTION
Nå klager den ikke om man importer fra både `date-fns` og `date-fns/locale`.