### PR TITLE
♻️ Remove redundant layout and padding

### DIFF
--- a/frontend/src/components/button-link.tsx
+++ b/frontend/src/components/button-link.tsx
@@ -1,5 +1,5 @@
 import type { ButtonProps } from '@chakra-ui/react';
-import { Button, useColorModeValue, Link } from '@chakra-ui/react';
+import { LinkBox, LinkOverlay, Button, useColorModeValue } from '@chakra-ui/react';
 import NextLink from 'next/link';
 
 interface Props extends ButtonProps {
@@ -14,18 +14,20 @@ const ButtonLink = ({ href, isExternal, ...props }: Props): JSX.Element => {
     const textColor = useColorModeValue('button.light.text', 'button.dark.text');
 
     return (
-        <Link as={NextLink} href={href} isExternal={isExternal}>
-            <Button
-                bg={bg}
-                color={textColor}
-                _hover={{ bg: hover }}
-                _active={{ borderColor: active }}
-                fontSize="xl"
-                borderRadius="0.5rem"
-                data-cy={href}
-                {...props}
-            />
-        </Link>
+        <LinkBox>
+            <LinkOverlay as={NextLink} href={href} isExternal={isExternal}>
+                <Button
+                    bg={bg}
+                    color={textColor}
+                    _hover={{ bg: hover }}
+                    _active={{ borderColor: active }}
+                    fontSize="xl"
+                    borderRadius="0.5rem"
+                    data-cy={href}
+                    {...props}
+                />
+            </LinkOverlay>
+        </LinkBox>
     );
 };
 

--- a/frontend/src/components/entry-box.tsx
+++ b/frontend/src/components/entry-box.tsx
@@ -48,14 +48,9 @@ const EntryBox = ({
                         registrationCounts={registrationCounts}
                     />
                 )}
-                <Spacer />
+                <Spacer my="4" />
                 {linkTo && (
-                    <ButtonLink
-                        href={linkTo}
-                        transition=".1s ease-out"
-                        marginTop="7"
-                        _hover={{ transform: 'scale(1.05)' }}
-                    >
+                    <ButtonLink href={linkTo} transition=".1s ease-out" _hover={{ transform: 'scale(1.05)' }}>
                         {isNorwegian ? 'Se mer' : 'See more'}
                     </ButtonLink>
                 )}

--- a/frontend/src/components/header-logo.tsx
+++ b/frontend/src/components/header-logo.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, LinkBox, LinkOverlay, Text, useColorModeValue } from '@chakra-ui/react';
+import { Box, LinkBox, LinkOverlay, Text, useColorModeValue } from '@chakra-ui/react';
 import { isFriday, isThursday, getDate, getHours, getMonth, getWeek, isMonday } from 'date-fns';
 import { nb } from 'date-fns/locale';
 import Image from 'next/image';
@@ -86,23 +86,21 @@ const HeaderLogo = () => {
 
     return (
         <LinkBox
-            p="1.05rem"
+            p="1rem"
             bg={bg}
             shadow="lg"
             data-cy="header-logo"
-            borderRadius="0.5rem"
+            borderRadius="lg"
             boxShadow="0 10px 20px 0 rgba(0, 0, 0, 0.1)"
-            mr="0rem"
-            pos="relative"
         >
             <LinkOverlay as={NextLink} href="/">
-                <Flex display={{ base: 'none', md: 'block' }}>
+                <Box display={{ base: 'none', md: 'block' }}>
                     <Image src={bigLogo} alt="logo" width={260} height={77} />
-                </Flex>
+                </Box>
 
-                <Flex display={{ base: 'block', md: 'none' }}>
+                <Box display={{ base: 'block', md: 'none' }}>
                     <Image src={smallLogo} alt="logo" width={90} height={90} />
-                </Flex>
+                </Box>
             </LinkOverlay>
 
             {logoAcc && <LogoAccesory iconSrc={logoAcc} h={40} w={40} />}

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Flex, Icon, IconButton, useColorModeValue, useDisclosure } from '@chakra-ui/react';
+import { Center, Flex, Icon, IconButton, Spacer, useColorModeValue, useDisclosure } from '@chakra-ui/react';
 import { memo, useRef } from 'react';
 import { IoIosMenu } from 'react-icons/io';
 import NavBar from '@components/navbar';
@@ -10,27 +10,36 @@ const Header = () => {
     const borderBg = useColorModeValue('bg.light.tertiary', 'bg.dark.tertiary');
 
     return (
-        <Box>
-            <Center borderColor={borderBg} data-cy="header" m="2rem auto">
-                <Flex w="90%" h="120px" alignItems="flex-end" maxW="1300" px={['0', '5%', '50']}>
-                    <HeaderLogo />
-                    <NavBar isOpen={isOpen} onClose={onClose} btnRef={menuButtonRef} />
-                    <IconButton
-                        variant="unstyled"
-                        ref={menuButtonRef}
-                        onClick={onOpen}
-                        display={['block', null, null, 'none']}
-                        aria-label="show navbar"
-                        icon={
-                            <Center>
-                                <Icon as={IoIosMenu} boxSize={10} />
-                            </Center>
-                        }
-                        data-cy="drawer-button"
-                    />
-                </Flex>
-            </Center>
-        </Box>
+        <Flex
+            w="90%"
+            maxW="1300"
+            px={['0', '5%', '50']}
+            alignItems="flex-end"
+            borderColor={borderBg}
+            data-cy="header"
+            my="2rem"
+            mx="auto"
+        >
+            <HeaderLogo />
+
+            <Spacer />
+
+            <NavBar isOpen={isOpen} onClose={onClose} btnRef={menuButtonRef} />
+
+            <IconButton
+                variant="unstyled"
+                ref={menuButtonRef}
+                onClick={onOpen}
+                display={['block', null, null, 'none']}
+                aria-label="show navbar"
+                icon={
+                    <Center>
+                        <Icon as={IoIosMenu} boxSize={10} />
+                    </Center>
+                }
+                data-cy="drawer-button"
+            />
+        </Flex>
     );
 };
 

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -67,18 +67,17 @@ const NavBar = ({ isOpen, onClose, btnRef }: Props): JSX.Element => {
     const isNorwegian = useLanguage();
 
     return (
-        <>
-            <Box flex="2 1 auto" data-cy="navbar-standard" pb="1rem" pl={['0.5rem', null, null, null, '3rem', '4rem']}>
-                <Flex
-                    display={['none', null, null, 'flex']}
-                    align="center"
-                    justify="space-between"
-                    w="full"
-                    direction="column"
-                >
-                    <NavLinks />
-                </Flex>
-            </Box>
+        <Box>
+            <Flex
+                display={['none', null, null, 'flex']}
+                align="center"
+                justify="space-between"
+                w="full"
+                direction="column"
+            >
+                <NavLinks />
+            </Flex>
+
             <Drawer isOpen={isOpen} placement="right" onClose={onClose} finalFocusRef={btnRef}>
                 <DrawerOverlay>
                     <DrawerContent data-cy="navbar-drawer">
@@ -94,7 +93,7 @@ const NavBar = ({ isOpen, onClose, btnRef }: Props): JSX.Element => {
                     </DrawerContent>
                 </DrawerOverlay>
             </Drawer>
-        </>
+        </Box>
     );
 };
 


### PR DESCRIPTION
Fjernet litt sånn unødvendig padding, margin osv som var på forsiden. Dette hadde som hensikt i å gjøre det lettere senere å bygge videre på disse komponentene. Ingenting av styling skal være endret. 

Liten UI bug med entrybox knappen var at man kunne trykkke på den over knappen.

Utvidelsen jeg bruker heter [Pesticide](https://addons.mozilla.org/en-US/firefox/addon/pesticide-for-firefox/?utm_content=addons-manager-reviews-link&utm_medium=firefox-browser&utm_source=firefox-browser).

## Header

<details>
<summary>Før</summary>
<br>

![før-header](https://user-images.githubusercontent.com/32321558/212880611-c844afa7-9b68-483e-81e6-cb9ae7e6cfa9.png)

</details>

<details>
<summary>Etter</summary>
<br>

![etter-header](https://user-images.githubusercontent.com/32321558/212881300-79ea785c-35d5-42e7-9a3f-a5e5700c6782.png)

</details>

## Entrybox knapp

<details>
<summary>Før</summary>
<br>

![før-entrybox-button](https://user-images.githubusercontent.com/32321558/212880839-ee326c6f-8cbb-4444-8c2d-ada70a9736a7.png)

</details>

<details>
<summary>Etter</summary>
<br>

![nå-entrybox-button](https://user-images.githubusercontent.com/32321558/212880880-bb478ae4-cdd4-4c46-87bf-8b208fc280f0.png)

</details>