### PR TITLE
🔇 Clean up output from backend logs

### DIFF
--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -1,12 +1,12 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
     <root level="trace">
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="org.eclipse.jetty" level="INFO"/>
-    <logger name="io.netty" level="INFO"/>
+    <logger name="io.netty" level="info"/>
+    <logger name="io.ktor.routing.Routing" level="debug"/>
 </configuration>


### PR DESCRIPTION
Fjerner output fra https://ktor.io/docs/routing-in-ktor.html#trace_routes, som ble default nå nylig. Er bare masse støy.