### PR TITLE
Fix readonly for happening regdate

### DIFF
--- a/cms/schemas/happening.ts
+++ b/cms/schemas/happening.ts
@@ -97,7 +97,8 @@ export default defineType({
             type: 'boolean',
             initialValue: false,
             hidden: ({ document, value }) => !value && !document?.happeningType,
-            readOnly: ({ value, document }) => value && (document?.registrationDate || document?.registrationDeadline),
+            readOnly: ({ value, document }) =>
+                !!(value && (document?.registrationDate || document?.registrationDeadline)),
         }),
         defineField({
             name: 'registrationDate',
@@ -157,7 +158,7 @@ export default defineType({
             initialValue: false,
             hidden: ({ document, value }) => !value && (!document?.registrationDate || !document?.registrationDeadline),
             readOnly: ({ value, document }) =>
-                value && (document?.studentGroupRegistrationDate || document?.studentGroups),
+                !!(value && (document?.studentGroupRegistrationDate || document?.studentGroups)),
         }),
         defineField({
             name: 'studentGroupRegistrationDate',


### PR DESCRIPTION
Nå blir `isRegistration` og `earlyReg` `readOnly` dersom noen av de avhengige feltene er definert.

![image](https://user-images.githubusercontent.com/11030698/216359002-eace4034-9e72-4d35-9e48-21aecce1a5af.png)
