### PR TITLE
Fix registrationDate validation error on spotrange

### DIFF
--- a/cms/schemas/happening.ts
+++ b/cms/schemas/happening.ts
@@ -109,7 +109,11 @@ export default defineType({
              */
             validation: (Rule) =>
                 Rule.custom((registrationDate, context) => {
-                    if ((context.document?.spotRanges as any[]).length > 0 && !registrationDate) {
+                    if (
+                        context.document?.spotRanges &&
+                        (context.document?.spotRanges as any[]).length > 0 &&
+                        !registrationDate
+                    ) {
                         return 'Må ha dato for påmelding om det er definert arrangementsplasser.';
                     }
 


### PR DESCRIPTION
La til en sjekk før `length`-checken som sjekker at `spotRange` i det hele tatt er definert. Dette er quick-fix, vi må refaktorere `spotRanges` til å ikke være reference asap.
