### PR TITLE
🐛 Make all fields of Sanity array required

### DIFF
--- a/cms/schemas/additionalQuestion.ts
+++ b/cms/schemas/additionalQuestion.ts
@@ -36,6 +36,7 @@ export default defineType({
             of: [
                 defineArrayMember({
                     type: 'string',
+                    validation: (Rule) => Rule.required(),
                 }),
             ],
         }),

--- a/cms/schemas/happening.ts
+++ b/cms/schemas/happening.ts
@@ -198,7 +198,7 @@ export default defineType({
             name: 'studentGroups',
             title: 'Hvilke studentgrupper har tidlig påmelding?',
             type: 'array',
-            of: [defineArrayMember({ type: 'string' })],
+            of: [defineArrayMember({ type: 'string', validation: (Rule) => Rule.required() })],
             /**
              * Må være satt dersom det er definert tidlig påmelding for studentgrupper.
              */
@@ -315,6 +315,7 @@ export default defineType({
                             type: 'additionalQuestion',
                         },
                     ],
+                    validation: (Rule) => Rule.required(),
                 }),
             ],
             hidden: ({ document, value }) => !value && !document?.isRegistration,
@@ -339,6 +340,7 @@ export default defineType({
                             type: 'spotRange',
                         },
                     ],
+                    validation: (Rule) => Rule.required(),
                 }),
             ],
             hidden: ({ document, value }) => !value && !document?.isRegistration,

--- a/cms/schemas/jobAdvert.ts
+++ b/cms/schemas/jobAdvert.ts
@@ -80,7 +80,7 @@ export default defineType({
             title: 'Sted(er)',
             validation: (Rule) => Rule.required().unique(),
             type: 'array',
-            of: [defineArrayMember({ type: 'string' })],
+            of: [defineArrayMember({ type: 'string', validation: (Rule) => Rule.required() })],
         }),
         defineField({
             name: 'jobType',
@@ -109,7 +109,7 @@ export default defineType({
                     .unique(),
             ],
             type: 'array',
-            of: [defineArrayMember({ type: 'number' })],
+            of: [defineArrayMember({ type: 'number', validation: (Rule) => Rule.required() })],
         }),
         defineField({
             name: 'weight',

--- a/cms/schemas/studentGroup.ts
+++ b/cms/schemas/studentGroup.ts
@@ -88,12 +88,14 @@ export default defineType({
                             name: 'role',
                             title: 'Rolle',
                             type: 'string',
+                            validation: (Rule) => Rule.required(),
                         }),
                         defineField({
                             name: 'profile',
                             title: 'Profil',
                             type: 'reference',
                             to: [{ type: 'profile' }],
+                            validation: (Rule) => Rule.required(),
                         }),
                     ],
                     preview: {


### PR DESCRIPTION
Dette gjør ikke selve feltet som bruker 'array' required, men gjør at alle feltene inne i array'et er required, om det er definert et array.

Ref. Slack fikser det problemet der man legger til medlem av undergruppe med tom tittel, men fikser nok en del andre edge cases også (tom spotRange sikkert?)