### PR TITLE
🐛 Fix wrong count on /event/[slug]

### DIFF
--- a/backend/src/main/kotlin/no/uib/echo/routes/HappeningRoutes.kt
+++ b/backend/src/main/kotlin/no/uib/echo/routes/HappeningRoutes.kt
@@ -131,6 +131,17 @@ fun Route.getHappeningInfo() {
             }
         }
 
+        val totalCount = countRegistrationsDegreeYear(slug, 1..5, false)
+
+        val totalCountDiff = totalCount - registrationCount.sumOf { it.regCount }
+        if (totalCountDiff > 0) {
+            val newRegistrationCount = listOf(
+                registrationCount.first().copy(regCount = registrationCount.first().regCount + totalCountDiff)
+            ) + registrationCount.drop(1)
+
+            call.respond(HttpStatusCode.OK, HappeningInfoJson(newRegistrationCount))
+        }
+
         call.respond(
             HttpStatusCode.OK,
             HappeningInfoJson(


### PR DESCRIPTION
Viser feil antall påmeldte pga. de fra Bedkom som er utenfor alle SpotRange's ikke blir telt med. Dette legger til de påmeldingene som ikke er i noen SpotRange på første SpotRange, så de blir telt med. Dette er likt sånn det funker når Bedkom utenfor SpotRange melder seg på, da blir de "registrert"/"telt" som en del av første SpotRange (i listen av SpotRange's).

Forsiden viser riktig antall siden den teller alle trinn uavhengig av SpotRange's.

Mye SpotRange men håper det ga mening.