### PR TITLE
Fix NaN in spotrange validation

### DIFF
--- a/cms/schemas/spotRange.ts
+++ b/cms/schemas/spotRange.ts
@@ -29,10 +29,7 @@ export default defineType({
             name: 'maxDegreeYear',
             title: 'Største trinn',
             type: 'number',
-            validation: (Rule) =>
-                Rule.required()
-                    .min(Number(Rule.valueOfField('minDegreeYear')))
-                    .max(5),
+            validation: (Rule) => Rule.required().min(Rule.valueOfField('minDegreeYear')).max(5),
         }),
         defineField({
             name: 'spots',


### PR DESCRIPTION
Ser ut som om sanity ikke liker `Number`-funksjonen, validationen tror at tallet er NaN. Jeg fjernet den funksjonen. Ser ikke ut som de bruker den i [dokumentasjonen](https://www.sanity.io/docs/validation#1d8eb8fbb695) heller.
