### PR TITLE
⚡️ Drastically reduce amount of happenings in queries from /index

### DIFF
--- a/frontend/src/lib/api/happening.ts
+++ b/frontend/src/lib/api/happening.ts
@@ -80,11 +80,17 @@ const HappeningAPI = {
      * @param type the type of happening to retrieve
      * @returns the n last happeninges
      */
-    getHappeningsByType: async (n: number, type: HappeningType): Promise<Array<Happening> | ErrorMessage> => {
+    getHappeningsByType: async (
+        n: number,
+        type: HappeningType,
+        onlyFuture: boolean = false,
+    ): Promise<Array<Happening> | ErrorMessage> => {
         try {
             const limit = n === 0 ? `` : `[0...${n}]`;
             const query = groq`
-                *[_type == "happening" && happeningType == "${type}" && !(_id in path('drafts.**'))] | order(date asc) {
+                *[_type == "happening" && happeningType == "${type}" && ${
+                onlyFuture ? 'dateTime(date) > dateTime(now()) &&' : ''
+            } !(_id in path('drafts.**'))] | order(date asc) {
                     title,
                     "slug": slug.current,
                     date,

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { Grid, GridItem, Heading, LinkBox, LinkOverlay, useBreakpointValue, VStack } from '@chakra-ui/react';
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
-import { isBefore, isFuture, parseISO } from 'date-fns';
+import { isFuture, parseISO } from 'date-fns';
 import type { GetStaticProps } from 'next';
 import NextLink from 'next/link';
 import EntryBox from '@components/entry-box';
@@ -146,8 +146,8 @@ export const getStaticProps: GetStaticProps = async () => {
     if (!adminKey) throw new Error('No ADMIN_KEY defined.');
 
     const [bedpresesResponse, eventsResponse, postsResponse, jobsResponse, bannerResponse] = await Promise.all([
-        HappeningAPI.getHappeningsByType(0, 'BEDPRES'),
-        HappeningAPI.getHappeningsByType(0, 'EVENT'),
+        HappeningAPI.getHappeningsByType(2, 'BEDPRES', true),
+        HappeningAPI.getHappeningsByType(3, 'EVENT', true),
         PostAPI.getPosts(0),
         JobAdvertAPI.getJobAdverts(3),
         BannerAPI.getBanner(),
@@ -165,26 +165,14 @@ export const getStaticProps: GetStaticProps = async () => {
         fs.writeFileSync('./public/rss.xml', rss);
     }
 
-    const events = eventsResponse
-        .filter((event: Happening) => {
-            return isBefore(new Date().setHours(0, 0, 0, 0), new Date(event.date));
-        })
-        .slice(0, 3);
-
-    const bedpreses = bedpresesResponse
-        .filter((bedpres: Happening) => {
-            return isBefore(new Date().setHours(0, 0, 0, 0), new Date(bedpres.date));
-        })
-        .slice(0, 2);
-
-    const slugs = [...bedpreses, ...events].map((happening: Happening) => happening.slug);
+    const slugs = [...bedpresesResponse, ...eventsResponse].map((happening: Happening) => happening.slug);
     const registrationCountsResponse = await RegistrationAPI.getRegistrationCountForSlugs(slugs, adminKey);
 
     return {
         props: {
-            bedpreses,
+            bedpreses: bedpresesResponse,
             posts: postsResponse.slice(0, process.env.NEXT_PUBLIC_ENABLE_JOB_ADVERTS?.toLowerCase() === 'true' ? 2 : 3),
-            events,
+            events: eventsResponse,
             jobs: jobsResponse,
             banner: bannerResponse ?? null,
             registrationCounts: isErrorMessage(registrationCountsResponse) ? [] : registrationCountsResponse,


### PR DESCRIPTION
Før så hentet vi alle happenings noensinne, og så filtrerte de etter dato. Dette førte til ekstremt unødvening load på backend, som måtte hente alle happenings noensinne hvert 30s hver gang noen er inne på forsiden.