### PR TITLE
🏗 Increase backend rate limit

### DIFF
--- a/backend/src/main/kotlin/no/uib/echo/plugins/RateLimit.kt
+++ b/backend/src/main/kotlin/no/uib/echo/plugins/RateLimit.kt
@@ -8,7 +8,7 @@ import kotlin.time.Duration.Companion.seconds
 fun Application.configureRateLimit() {
     install(RateLimit) {
         global {
-            rateLimiter(limit = 200, refillPeriod = 60.seconds)
+            rateLimiter(limit = 10000, refillPeriod = 60.seconds)
         }
     }
 }

--- a/backend/src/test/kotlin/no/uib/echo/status/GetStatusTest.kt
+++ b/backend/src/test/kotlin/no/uib/echo/status/GetStatusTest.kt
@@ -16,9 +16,9 @@ class GetStatusTest {
         }
 
     @Test
-    fun `Should rate limit after 200 requests`() =
+    fun `Should rate limit after 10000 requests`() =
         testApplication {
-            for (i in 1..200) {
+            for (i in 1..10000) {
                 val res = client.get("/status")
                 res.status shouldBe HttpStatusCode.OK
             }


### PR DESCRIPTION
Mellom 12:00:17 og 12:00:47 i dag så fikk load balancer'en vi har foran de to backend-container'ene `429 – Too Many Requests` på alle forespørsler. Rate limit til Ktor er IP-basert, som betyr at alle forespørsler til load balancer (altså alle forespørsler) teller mot rate limit på 200. Tidligere har dette ikke vært et problem siden brukere har sendt forespørsler direkte, og det skal litt til for én bruker å sende 200 på under 60 sekunder. Beste løsning er nok å sette rate limit på load balancer i stedet men dette burde fikse ting midlertidlig, og fortsatt beskytte oss mot spam/DDoS.