### PR TITLE
🏗️ Replace Container Instances with Container Apps

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ env:
   TF_VAR_admin_key_prod: ${{ secrets.ADMIN_KEY_PROD }}
   TF_VAR_auth_secret: ${{ secrets.AUTH_SECRET }}
   TF_VAR_sendgrid_api_key: ${{ secrets.SENDGRID_API_KEY }}
-  TF_VAR_container_count_prod: 2
+  TF_VAR_revision_suffix: ${{ github.sha }}
   ARM_CLIENT_ID: 225cb793-e592-482e-8612-2318bd5e0a6c
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_SUBSCRIPTION_ID: f16e6916-1e71-42a0-9df3-0246b805f432
@@ -125,28 +125,3 @@ jobs:
           cd terraform/main
           terraform init -lockfile=readonly
           terraform apply -auto-approve -lock-timeout=15m
-
-      - name: Redeploy new containers
-        if: steps.changed-files-backend.outputs.any_changed == 'true'
-        run: |
-          cd terraform/main
-          terraform init -lockfile=readonly
-          # Dev container group
-          terraform destroy -auto-approve \
-            -target=module.dev.module.cg.azurerm_container_group.backend[0] \
-            -lock-timeout=15m
-          terraform apply -auto-approve \
-            -target=module.dev.module.cg.azurerm_container_group.backend[0] \
-            -lock-timeout=15m
-          # Prod container groups
-          {
-            for ((i = 0; i <= TF_VAR_container_count_prod; i++))
-            do
-              terraform destroy -auto-approve \
-                -target=module.prod.module.cg.azurerm_container_group.backend[$i] \
-                -lock-timeout=15m
-              terraform apply -auto-approve \
-                -target=module.prod.module.cg.azurerm_container_group.backend[$i] \
-                -lock-timeout=15m
-            done
-          }

--- a/.github/workflows/terraform_format_plan.yaml
+++ b/.github/workflows/terraform_format_plan.yaml
@@ -15,7 +15,7 @@ env:
   TF_VAR_admin_key_prod: ${{ secrets.ADMIN_KEY_PROD }}
   TF_VAR_auth_secret: ${{ secrets.AUTH_SECRET }}
   TF_VAR_sendgrid_api_key: ${{ secrets.SENDGRID_API_KEY }}
-  TF_VAR_container_count_prod: 2
+  TF_VAR_revision_suffix: ${{ github.sha }}
   ARM_CLIENT_ID: 225cb793-e592-482e-8612-2318bd5e0a6c
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_SUBSCRIPTION_ID: f16e6916-1e71-42a0-9df3-0246b805f432

--- a/terraform/main/.terraform.lock.hcl
+++ b/terraform/main/.terraform.lock.hcl
@@ -5,16 +5,18 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.44.1"
   constraints = "3.44.1"
   hashes = [
-    "h1:6a78mchLMsrharzI5XDgKfARCNJBXc4b3bmtkX7u1rY=",
-    "h1:7zeUPl2nDhKnWHpAeKy+7Cued79RDgwacN/qpTIim64=",
     "h1:EkFaulKIAb3nb7svbpM18Tf7rl+ajVCXnXvP//Yvw2M=",
-    "h1:IJibVc166uvQ22fm9zcd+aQUfIsMsxR8ZW8STGzW/Qk=",
-    "h1:IXRbzmvSs+7NPGduQXgKiFY0jjhKDy0i5baLHXtc4/c=",
-    "h1:M2xbHeaGPfSJUwov1cigxzzlSY0F3eT2ZGGgwAyQXoM=",
-    "h1:NC8u8mDfk7eKda5ShYj5kYpweQi7PPTh4WHthSnQQHU=",
-    "h1:Nruhll1zw9gYR9KWbrVoN9npRKboPbEWbvq0BTCUa64=",
-    "h1:dq7s/3sZrI4oLWL/NUlOcOD3HGkzimRmEvFiWX+ENRw=",
-    "h1:iqP1wYNUezvM7Ygx2RPT37XMa6M9BZMEo/ce2f7tEKw=",
-    "h1:nBO2eEnHHyoTpEFjoBXcu0+7HJ30RYk8LVFmFRnZi8g=",
+    "zh:0a1761b5aeec47d5019114976de5eb9832dea1d57d632ca6fa464b99b782d1c1",
+    "zh:0e9c96fa7ed6d55a3f3a646ff346298c8b7728331bb3a74875f78ecb7d245c16",
+    "zh:1aa953a692c7b5b10219343f0238f4624ac988e247721b6ec6b1bed2b81f7ceb",
+    "zh:237258af1a1ce8a0aed8f6cdb03c69ea83ff4f3a46d5bd1466cd503f0b5aded8",
+    "zh:542067eeeb3b4e286e92d646e0f40426e204ed268973343e585aa521f075f8dc",
+    "zh:8326d52460252fd335ae97d0fabd9f5d90061a4fbeb273618f4067be3eb4e75a",
+    "zh:97a2b802bf6e204476131ddb7a91e832568ee8da3b0515ed23361c9f72ca9706",
+    "zh:9ae5a52ec85e0ad218e2ce9d33859f17afbb2fb2a690bf60d5f48fc7680e7fb0",
+    "zh:b17e77aff310e232f541334ba1858b5125ea0e527a5d6824de017192d8d8a3a2",
+    "zh:c469ba6681535c07c58dad6c1b59b056912300a7c91137ddc0103ef16b1d5697",
+    "zh:cea6026ef8fb5512d14c1ba6fdf36b90a09de536d4e4afad96b926af39114f74",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/main/dev/main.tf
+++ b/terraform/main/dev/main.tf
@@ -37,12 +37,11 @@ module "db" {
   db_password = var.db_password
 }
 
-module "cg" {
-  source = "../modules/container_group"
+module "ca" {
+  source = "../modules/container_app"
 
   rg_name          = azurerm_resource_group.rg.name
-  law_wid          = azurerm_log_analytics_workspace.law.workspace_id
-  law_key          = azurerm_log_analytics_workspace.law.primary_shared_key
+  law_id           = azurerm_log_analytics_workspace.law.id
   location         = azurerm_resource_group.rg.location
   environment      = local.environment
   db_user          = local.db_user
@@ -50,5 +49,6 @@ module "cg" {
   db_fqdn          = module.db.fqdn
   admin_key        = var.admin_key
   auth_secret      = var.auth_secret
-  sendgrid_api_key = null
+  sendgrid_api_key = var.sendgrid_api_key
+  revision_suffix  = var.revision_suffix
 }

--- a/terraform/main/dev/outputs.tf
+++ b/terraform/main/dev/outputs.tf
@@ -1,3 +1,3 @@
 output "backend_url" {
-  value = module.cg.backend_url
+  value = module.ca.backend_url
 }

--- a/terraform/main/dev/variables.tf
+++ b/terraform/main/dev/variables.tf
@@ -18,3 +18,13 @@ variable "auth_secret" {
   type        = string
   description = "The AUTH_SECRET for the backend."
 }
+
+variable "sendgrid_api_key" {
+  type        = string
+  description = "The API key for SendGrid."
+}
+
+variable "revision_suffix" {
+  type        = string
+  description = "The revision suffix to use for the new revision of the Container App."
+}

--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -28,17 +28,20 @@ module "prod" {
   source = "./prod"
 
   location         = var.location
-  container_count  = var.container_count_prod
   db_password      = var.db_password_prod
   admin_key        = var.admin_key_prod
+  auth_secret      = var.auth_secret
   sendgrid_api_key = var.sendgrid_api_key
+  revision_suffix  = var.revision_suffix
 }
 
 module "dev" {
   source = "./dev"
 
-  location    = var.location
-  db_password = var.db_password_dev
-  admin_key   = var.admin_key_dev
-  auth_secret = var.auth_secret
+  location         = var.location
+  db_password      = var.db_password_dev
+  admin_key        = var.admin_key_dev
+  auth_secret      = var.auth_secret
+  sendgrid_api_key = var.sendgrid_api_key
+  revision_suffix  = var.revision_suffix
 }

--- a/terraform/main/modules/container_app/main.tf
+++ b/terraform/main/modules/container_app/main.tf
@@ -1,0 +1,113 @@
+# Main containers
+
+resource "azurerm_container_app_environment" "backend_env" {
+  name                       = "${var.rg_name}-env"
+  location                   = var.location
+  resource_group_name        = var.rg_name
+  log_analytics_workspace_id = var.law_id
+
+  tags = {
+    "environment" = var.environment
+  }
+}
+
+resource "azurerm_container_app" "backend" {
+  name                         = var.rg_name
+  container_app_environment_id = azurerm_container_app_environment.backend_env.id
+  resource_group_name          = var.rg_name
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "backend"
+      image  = "ghcr.io/echo-webkom/echo-web/backend:latest"
+      cpu    = var.environment == "production" ? "0.5" : "0.25"
+      memory = var.environment == "production" ? "1Gi" : "0.5Gi"
+
+      liveness_probe {
+        transport = "HTTP"
+        path      = "/status"
+        port      = "8080"
+      }
+
+      readiness_probe {
+        transport = "HTTP"
+        path      = "/status"
+        port      = "8080"
+      }
+
+      env {
+        name  = "ENVIRONMENT"
+        value = var.environment
+      }
+
+      env {
+        name  = "USE_JWT_TEST"
+        value = var.environment != "production"
+      }
+
+      env {
+        name  = "SEND_EMAIL_REGISTRATION"
+        value = "true"
+      }
+
+      env {
+        name        = "DATABASE_URL"
+        secret_name = "database-url"
+      }
+
+      env {
+        name        = "ADMIN_KEY"
+        secret_name = "admin-key"
+      }
+
+      env {
+        name  = "AUTH_SECRET"
+        value = "auth-secret"
+      }
+
+      env {
+        name        = "SENDGRID_API_KEY"
+        secret_name = "sendgrid-api-key"
+      }
+    }
+
+    min_replicas    = var.environment == "production" ? 1 : 0
+    max_replicas    = var.environment == "production" ? 2 : 1
+    revision_suffix = substr(var.revision_suffix, 0, 10)
+  }
+
+  ingress {
+    target_port      = "8080"
+    external_enabled = true
+
+    traffic_weight {
+      percentage      = 100
+      latest_revision = true
+    }
+  }
+
+  secret {
+    name  = "database-url"
+    value = "postgres://${var.db_user}:${var.db_password}@${var.db_fqdn}:5432/postgres"
+  }
+
+  secret {
+    name  = "admin-key"
+    value = var.admin_key
+  }
+
+  secret {
+    name  = "auth-secret"
+    value = var.auth_secret
+  }
+
+  secret {
+    name  = "sendgrid-api-key"
+    value = var.sendgrid_api_key
+  }
+
+  tags = {
+    "environment" = var.environment
+  }
+}

--- a/terraform/main/modules/container_app/outputs.tf
+++ b/terraform/main/modules/container_app/outputs.tf
@@ -1,0 +1,3 @@
+output "backend_url" {
+  value = "https://${azurerm_container_app.backend.ingress.0.fqdn}"
+}

--- a/terraform/main/modules/container_app/variables.tf
+++ b/terraform/main/modules/container_app/variables.tf
@@ -1,0 +1,60 @@
+variable "rg_name" {
+  type        = string
+  description = "The name of the resource group in which to create the resources."
+}
+
+variable "law_id" {
+  type        = string
+  description = "The ID of the Log Analytics workspace."
+}
+
+variable "location" {
+  type        = string
+  description = "The Azure location where the resources should be created."
+  default     = "norwayeast"
+}
+
+variable "environment" {
+  type        = string
+  description = "Tags the resources with the environment, and sets backend environment."
+
+  validation {
+    condition     = contains(["production", "development", "preview"], var.environment)
+    error_message = "Valid values for environment are: 'production', 'development' and 'preview'."
+  }
+}
+
+variable "db_user" {
+  type        = string
+  description = "The name of the admin database user."
+}
+
+variable "db_password" {
+  type        = string
+  description = "The password for the admin database user."
+}
+
+variable "db_fqdn" {
+  type        = string
+  description = "The fully qualified domain name (URL, basically) of the database."
+}
+
+variable "admin_key" {
+  type        = string
+  description = "The ADMIN_KEY to use for the backend."
+}
+
+variable "auth_secret" {
+  type        = string
+  description = "The AUTH_SECRET for the development and preview backend."
+}
+
+variable "sendgrid_api_key" {
+  type        = string
+  description = "The API key for SendGrid."
+}
+
+variable "revision_suffix" {
+  type        = string
+  description = "The revision suffix to use for the new revision of the Container App."
+}

--- a/terraform/main/prod/main.tf
+++ b/terraform/main/prod/main.tf
@@ -37,19 +37,18 @@ module "db" {
   db_password = var.db_password
 }
 
-module "cg" {
-  source = "../modules/container_group"
+module "ca" {
+  source = "../modules/container_app"
 
   rg_name          = azurerm_resource_group.rg.name
-  law_wid          = azurerm_log_analytics_workspace.law.workspace_id
-  law_key          = azurerm_log_analytics_workspace.law.primary_shared_key
+  law_id           = azurerm_log_analytics_workspace.law.id
   location         = azurerm_resource_group.rg.location
   environment      = local.environment
   db_user          = local.db_user
   db_password      = var.db_password
   db_fqdn          = module.db.fqdn
   admin_key        = var.admin_key
-  auth_secret      = null
+  auth_secret      = var.auth_secret
   sendgrid_api_key = var.sendgrid_api_key
-  container_count  = var.container_count
+  revision_suffix  = var.revision_suffix
 }

--- a/terraform/main/prod/outputs.tf
+++ b/terraform/main/prod/outputs.tf
@@ -1,3 +1,3 @@
 output "backend_url" {
-  value = module.cg.backend_url
+  value = module.ca.backend_url
 }

--- a/terraform/main/prod/variables.tf
+++ b/terraform/main/prod/variables.tf
@@ -4,11 +4,6 @@ variable "location" {
   default     = "norwayeast"
 }
 
-variable "container_count" {
-  type        = number
-  description = "The number of containers to create."
-}
-
 variable "db_password" {
   type        = string
   description = "The password for the admin database user."
@@ -19,7 +14,17 @@ variable "admin_key" {
   description = "The ADMIN_KEY to use for the backend."
 }
 
+variable "auth_secret" {
+  type        = string
+  description = "The AUTH_SECRET for the backend."
+}
+
 variable "sendgrid_api_key" {
   type        = string
   description = "The API key for SendGrid."
+}
+
+variable "revision_suffix" {
+  type        = string
+  description = "The revision suffix to use for the new revision of the Container App."
 }

--- a/terraform/main/variables.tf
+++ b/terraform/main/variables.tf
@@ -4,11 +4,6 @@ variable "location" {
   default     = "norwayeast"
 }
 
-variable "container_count_prod" {
-  type        = number
-  description = "The number of containers to create in the production environment."
-}
-
 variable "db_password_prod" {
   type        = string
   description = "The password for the admin user on the production database."
@@ -37,4 +32,9 @@ variable "auth_secret" {
 variable "sendgrid_api_key" {
   type        = string
   description = "The API key for SendGrid."
+}
+
+variable "revision_suffix" {
+  type        = string
+  description = "The revision suffix to use for the new revision of the Container App."
 }


### PR DESCRIPTION
Vi har brukt Azure Container Instances til nå, som basically er en VM som kjører Docker images.
ACI er barebones, og vi har måttet fikse disse tingene selv:
- HTTPS / SSL
- horisontal scaling (hvor mange containere vi har)
- re-deploy av nytt image

Azure Container Apps fikser alt dette for oss, og gir en mer forståelig interface i Azure Portal. Det blir også mye mindre ressurser i Azure (pga. auto-SSL), som gjør Portal cleanere og lettere å forstå. Vi har ikke brukt ACA ftidligere pga. tjenesten ikke har vært tilgjengelig i Terraform før nylig.

#### Mulig at `deploy.yaml` kan faile eller ikke deploye riktig, umulig å teste uten å merge.
#### Burde merges når det er lite aktivitet, f.eks. kvelden/helgen, siden backend vil være nede noen minutter.

#### Må gjøres etter merge:
- [ ] endre `BACKEND_URL`  for production og development/preview i Vercel.