### PR TITLE
🐛 Fix OG image overflow on long bedpres titles

### DIFF
--- a/frontend/src/pages/api/og/bedpres.tsx
+++ b/frontend/src/pages/api/og/bedpres.tsx
@@ -4,15 +4,14 @@
 import { ImageResponse } from '@vercel/og';
 import type { NextRequest } from 'next/server';
 
-// eslint-disable-next-line import/exports-last
-export const config = {
-    runtime: 'experimental-edge',
+const config = {
+    runtime: 'edge',
 };
 
 // eslint-disable-next-line unicorn/prefer-top-level-await
 const font = fetch(new URL('../../../assets/BebasNeue-Regular.ttf', import.meta.url)).then((res) => res.arrayBuffer());
 
-export default async function OGImage(req: NextRequest) {
+async function OGImage(req: NextRequest) {
     try {
         const fontData = await font;
 
@@ -103,3 +102,6 @@ export default async function OGImage(req: NextRequest) {
         });
     }
 }
+
+export default OGImage;
+export { config };

--- a/frontend/src/pages/api/og/bedpres.tsx
+++ b/frontend/src/pages/api/og/bedpres.tsx
@@ -21,6 +21,8 @@ export default async function OGImage(req: NextRequest) {
         const title = searchParams.get('title') ?? 'Bedrift';
         const logoUrl = searchParams.get('logoUrl') ?? '../../../assets/small-echo-logo.png';
 
+        const isLongTitle = title.length >= 13;
+
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
         return new ImageResponse(
             (
@@ -66,14 +68,18 @@ export default async function OGImage(req: NextRequest) {
                         <p
                             style={{
                                 position: 'absolute',
+                                display: 'flex',
+                                flexDirection: isLongTitle ? 'column' : 'row',
+                                gap: 15,
                                 bottom: '0%',
                                 left: '50%',
-                                transform: 'translate(-50%, -20%)',
-                                fontSize: 110,
+                                transform: `translate(-50%, ${isLongTitle ? '0' : '-20'}%)`,
+                                fontSize: isLongTitle ? 80 : 110,
                                 fontFamily: '"Bebas Neue"',
                             }}
                         >
-                            Bedpres med {title}
+                            <span tw="mx-auto">Bedpres med</span>
+                            <span tw="mx-auto">{title}</span>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
<img width="1305" alt="image" src="https://user-images.githubusercontent.com/32321558/225328252-8d214144-4a71-47e8-a433-d743be376b41.png">
