### PR TITLE
✨ Fjernet selv-avmelding på bedpresser

### DIFF
--- a/frontend/src/components/deregistration-button.tsx
+++ b/frontend/src/components/deregistration-button.tsx
@@ -124,9 +124,15 @@ const DeregistrationButton = ({ happening, isWaitlist }: Props): JSX.Element => 
 
     return (
         <>
-            <Button data-cy="del-btn" w="100%" colorScheme="red" onClick={onOpen}>
-                {isNorwegian ? 'Meld deg av' : 'Deregister'}
-            </Button>
+            {happening.happeningType === 'BEDPRES' ? (
+                <Button data-cy="del-btn" w="100%" colorScheme="red" isDisabled={true}>
+                    {isNorwegian ? 'Du er allerede meldt på' : 'Already registered'}
+                </Button>
+            ) : (
+                <Button data-cy="del-btn" w="100%" colorScheme="red" onClick={onOpen}>
+                    {isNorwegian ? 'Meld deg av' : 'Deregister'}
+                </Button>
+            )}
 
             <Modal
                 isOpen={isOpen}


### PR DESCRIPTION
Snakka med bedkom i dag som synes det at folk kan melde seg av når som helst på bedpresser gjør at de mister kontroll (spesielt når de ikke får en slags varsling). Temporary solution e bare å fjerna muligheten til det på bedpresser, men skal snakka med resten av HS på om med ska gjør en endring på dette.

Vanlig arrangement e vanlig:
<img width="389" alt="SCR-20230911-srfy" src="https://github.com/echo-webkom/echo-web/assets/91483527/31dba37b-78e3-4295-abe7-462deac2f507">
Bedpres:
<img width="374" alt="SCR-20230911-srez" src="https://github.com/echo-webkom/echo-web/assets/91483527/0d45c736-0cd8-438f-b48b-b208aca97184">
